### PR TITLE
Move blocking CLLocationManager locationServicesEnabled call to background

### DIFF
--- a/Sources/Tools/LocationTool.swift
+++ b/Sources/Tools/LocationTool.swift
@@ -430,11 +430,13 @@ public struct LocationTool: Tool {
   }
 
   /// Checks if location authorization is sufficient for the current platform
-  @MainActor
-  private func checkLocationAuthorization() -> AuthorizationResult {
-    let status = locationManager.authorizationStatus
+  private func checkLocationAuthorization() async -> AuthorizationResult {
+    let status = await MainActor.run { locationManager.authorizationStatus }
+    let servicesEnabled = await Task(priority: .userInitiated) {
+      CLLocationManager.locationServicesEnabled()
+    }.value
 
-    guard CLLocationManager.locationServicesEnabled() else {
+    guard servicesEnabled else {
       return AuthorizationResult(
         status: status,
         isAuthorized: false,


### PR DESCRIPTION
Moves blocking `CLLocationManager.locationServicesEnabled()` call to background thread to avoid locking UI/main thread

Ensures accessing `locationManager` still happens in main thread

Validated all unit tests passed and location tool still works

closes #11 