### PR TITLE
Add transcript history transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A collection of tools and utilities for Apple's Foundation Models Framework that
   - [WebTool](#webtool)
 - [Utilities](#utilities)
   - [Token Counting](#token-counting)
+  - [Transcript History Transforms](#transcript-history-transforms)
 - [Usage Examples](#usage-examples)
   - [Direct Tool Usage](#direct-tool-usage)
   - [Model Integration](#model-integration)
@@ -664,6 +665,8 @@ FoundationModelsTools provides comprehensive token counting and context window m
 **Context Management:**
 - `isApproachingLimit(threshold:maxTokens:)` - Check if approaching context limits
 - `entriesWithinTokenBudget(_:)` - Sliding window implementation for long conversations
+- `rollingWindow(entries:)` - Keep the most recent transcript entries by count
+- `droppingCompletedToolCalls()` - Remove older completed tool-call exchanges
 
 #### Basic Token Counting
 
@@ -714,6 +717,18 @@ let newTranscript = Transcript(trimmedEntries)
 // - Includes as many recent entries as possible within budget
 // - Preserves conversation recency
 ```
+
+### Transcript History Transforms
+
+Use entry-level history transforms when you want lightweight transcript cleanup before building the next session or prompt history.
+
+```swift
+let compactEntries = transcript
+    .droppingCompletedToolCalls()
+    .rollingWindow(entries: 10)
+```
+
+`rollingWindow(entries:)` keeps the latest entries exactly by count. `droppingCompletedToolCalls()` removes older tool-call and tool-output entries while preserving the latest active tool exchange and all non-tool entries.
 
 #### Token Estimation Functions
 

--- a/Sources/Extensions/Transcript+HistoryTransforms.swift
+++ b/Sources/Extensions/Transcript+HistoryTransforms.swift
@@ -1,0 +1,56 @@
+//
+//  Transcript+HistoryTransforms.swift
+//  FoundationModelsTools
+//
+//  Transcript history transforms for Foundation Models conversations.
+//
+
+import FoundationModels
+
+extension Collection where Element == Transcript.Entry {
+  /// Returns the most recent transcript entries.
+  ///
+  /// This is an entry-count rolling window. Unlike ``entriesWithinTokenBudget(_:)``,
+  /// it does not preserve instructions specially or estimate token usage. It
+  /// mirrors the entry-window behavior used by Foundation Models history
+  /// profile modifiers.
+  ///
+  /// - Parameter entries: The maximum number of recent entries to keep.
+  /// - Returns: The latest entries in chronological order.
+  public func rollingWindow(entries: Int) -> [Transcript.Entry] {
+    guard entries > 0 else { return [] }
+    return Array(suffix(entries))
+  }
+
+  /// Returns transcript entries with older completed tool-call exchanges removed.
+  ///
+  /// Tool calls and tool outputs before the most recent assistant response or
+  /// tool-call entry are removed. The most recent response/tool-call entry and
+  /// everything after it is preserved.
+  ///
+  /// This keeps old tool chatter from growing context while retaining the latest
+  /// active tool exchange.
+  public func droppingCompletedToolCalls() -> [Transcript.Entry] {
+    let entries = Array(self)
+
+    guard !entries.isEmpty else {
+      return []
+    }
+
+    let lastOutputIndex =
+      entries.lastIndex { entry in
+        if case .response = entry { return true }
+        if case .toolCalls = entry { return true }
+        return false
+      } ?? entries.startIndex
+
+    let prefix = entries[..<lastOutputIndex].filter { entry in
+      if case .toolCalls = entry { return false }
+      if case .toolOutput = entry { return false }
+      return true
+    }
+
+    let suffix = entries[lastOutputIndex...]
+    return Array(prefix + suffix)
+  }
+}

--- a/Tests/FoundationModelsToolsTests/TokenCountingTests.swift
+++ b/Tests/FoundationModelsToolsTests/TokenCountingTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import FoundationModels
 import Testing
 @testable import FoundationModelsTools
 
@@ -110,5 +111,221 @@ struct TokenEstimationAccuracyTests {
     let tokens = estimateTokens(from: text)
 
     #expect(tokens > 0)
+  }
+}
+
+@Suite("Transcript History Transform Tests")
+struct TranscriptHistoryTransformTests {
+
+  @Test("Rolling window keeps the most recent entries")
+  func rollingWindowKeepsMostRecentEntries() {
+    let entries: [Transcript.Entry] = [
+      .instructions(.foundationModelsTools("System")),
+      .prompt(.foundationModelsTools("First")),
+      .toolOutput(.foundationModelsTools(id: "first-output", text: "First answer")),
+      .prompt(.foundationModelsTools("Second")),
+      .toolOutput(.foundationModelsTools(id: "second-output", text: "Second answer")),
+    ]
+
+    let window = entries.rollingWindow(entries: 3)
+
+    #expect(window.count == 3)
+    #expect(window.map { $0.foundationModelsToolsText } == [
+      "First answer",
+      "Second",
+      "Second answer",
+    ])
+  }
+
+  @Test("Rolling window returns empty array for non-positive sizes")
+  func rollingWindowReturnsEmptyForNonPositiveSizes() {
+    let entries: [Transcript.Entry] = [
+      .prompt(.foundationModelsTools("First")),
+      .toolOutput(.foundationModelsTools(id: "first-output", text: "First answer")),
+    ]
+
+    #expect(entries.rollingWindow(entries: 0).isEmpty)
+    #expect(entries.rollingWindow(entries: -1).isEmpty)
+  }
+
+  @Test("Rolling window can split an entry pair")
+  func rollingWindowCanSplitEntryPair() {
+    let entries: [Transcript.Entry] = [
+      .prompt(.foundationModelsTools("First")),
+      .toolOutput(.foundationModelsTools(id: "first-output", text: "First answer")),
+      .prompt(.foundationModelsTools("Second")),
+    ]
+
+    let window = entries.rollingWindow(entries: 2)
+
+    #expect(window.map { $0.foundationModelsToolsText } == [
+      "First answer",
+      "Second",
+    ])
+  }
+
+  @Test("Dropping completed tool calls removes older tool exchanges")
+  func droppingCompletedToolCallsRemovesOlderToolExchanges() {
+    let oldToolCalls = Transcript.ToolCalls(id: "old-calls", [])
+    let oldToolOutput = Transcript.ToolOutput(
+      id: "old-output",
+      toolName: "search",
+      segments: [.text(Transcript.TextSegment(content: "Old search output"))]
+    )
+    let latestToolCalls = Transcript.ToolCalls(id: "latest-calls", [])
+    let latestToolOutput = Transcript.ToolOutput(
+      id: "latest-output",
+      toolName: "lookup",
+      segments: [.text(Transcript.TextSegment(content: "Latest lookup output"))]
+    )
+
+    let entries: [Transcript.Entry] = [
+      .instructions(.foundationModelsTools("System")),
+      .prompt(.foundationModelsTools("First")),
+      .toolCalls(oldToolCalls),
+      .toolOutput(oldToolOutput),
+      .prompt(.foundationModelsTools("Second")),
+      .toolCalls(latestToolCalls),
+      .toolOutput(latestToolOutput),
+      .prompt(.foundationModelsTools("Continue")),
+    ]
+
+    let transformed = entries.droppingCompletedToolCalls()
+
+    #expect(transformed.map { $0.foundationModelsToolsKind } == [
+      "instructions",
+      "prompt",
+      "prompt",
+      "toolCalls",
+      "toolOutput",
+      "prompt",
+    ])
+    #expect(transformed.contains { entry in
+      if case .toolOutput(let output) = entry {
+        return output.id == "old-output"
+      }
+      return false
+    } == false)
+    #expect(transformed.contains { entry in
+      if case .toolCalls(let calls) = entry {
+        return calls.id == "latest-calls"
+      }
+      return false
+    })
+  }
+
+  @Test("Dropping completed tool calls keeps current tool exchange")
+  func droppingCompletedToolCallsKeepsCurrentToolExchange() {
+    let toolCalls = Transcript.ToolCalls(id: "current-calls", [])
+    let toolOutput = Transcript.ToolOutput(
+      id: "current-output",
+      toolName: "search",
+      segments: [.text(Transcript.TextSegment(content: "Current search output"))]
+    )
+
+    let entries: [Transcript.Entry] = [
+      .instructions(.foundationModelsTools("System")),
+      .prompt(.foundationModelsTools("First")),
+      .toolCalls(toolCalls),
+      .toolOutput(toolOutput),
+    ]
+
+    let transformed = entries.droppingCompletedToolCalls()
+
+    #expect(transformed.map { $0.foundationModelsToolsKind } == [
+      "instructions",
+      "prompt",
+      "toolCalls",
+      "toolOutput",
+    ])
+    #expect(transformed.contains { entry in
+      if case .toolOutput(let output) = entry {
+        return output.id == "current-output"
+      }
+      return false
+    })
+  }
+
+  @Test("Dropping completed tool calls preserves transcript with no outputs")
+  func droppingCompletedToolCallsPreservesTranscriptWithNoOutputs() {
+    let entries: [Transcript.Entry] = [
+      .instructions(.foundationModelsTools("System")),
+      .prompt(.foundationModelsTools("First")),
+      .prompt(.foundationModelsTools("Second")),
+    ]
+
+    let transformed = entries.droppingCompletedToolCalls()
+
+    #expect(transformed.map { $0.foundationModelsToolsText } == [
+      "System",
+      "First",
+      "Second",
+    ])
+  }
+}
+
+private extension Transcript.Entry {
+  var foundationModelsToolsKind: String {
+    if case .instructions = self { return "instructions" }
+    if case .prompt = self { return "prompt" }
+    if case .toolCalls = self { return "toolCalls" }
+    if case .toolOutput = self { return "toolOutput" }
+    if case .response = self { return "response" }
+    return "unknown"
+  }
+
+  var foundationModelsToolsText: String {
+    if case .instructions(let instructions) = self {
+      return instructions.segments.foundationModelsToolsText
+    }
+    if case .prompt(let prompt) = self {
+      return prompt.segments.foundationModelsToolsText
+    }
+    if case .toolOutput(let output) = self {
+      return output.segments.foundationModelsToolsText
+    }
+    if case .response(let response) = self {
+      return response.segments.foundationModelsToolsText
+    }
+    if case .toolCalls(let calls) = self {
+      return calls.id
+    }
+    return ""
+  }
+}
+
+private extension [Transcript.Segment] {
+  var foundationModelsToolsText: String {
+    compactMap { segment in
+      if case .text(let text) = segment {
+        return text.content
+      }
+      return nil
+    }.joined(separator: "\n")
+  }
+}
+
+private extension Transcript.Instructions {
+  static func foundationModelsTools(_ text: String) -> Self {
+    Self(
+      segments: [.text(Transcript.TextSegment(content: text))],
+      toolDefinitions: []
+    )
+  }
+}
+
+private extension Transcript.Prompt {
+  static func foundationModelsTools(_ text: String) -> Self {
+    Self(segments: [.text(Transcript.TextSegment(content: text))])
+  }
+}
+
+private extension Transcript.ToolOutput {
+  static func foundationModelsTools(id: String, text: String) -> Self {
+    Self(
+      id: id,
+      toolName: "testTool",
+      segments: [.text(Transcript.TextSegment(content: text))]
+    )
   }
 }


### PR DESCRIPTION
Summary

- add entry-level transcript rollingWindow(entries:) for count-based history windows
- add droppingCompletedToolCalls() to remove older completed tool-call/tool-output exchanges while preserving the latest active exchange
- document the new transcript history helpers in the README
- add parity tests for the Apple utilities behavior, including naive rolling-window splitting and current tool exchange preservation

Compatibility

- This PR intentionally avoids OS 27-only APIs. The helpers work on collections of Transcript.Entry and do not use DynamicProfile or new transcript cases.
- Verified on Xcode 26.5 beta and Xcode 26.3, which is the actual compatibility target for this package.

Apple utilities comparison

- Compared against apple/foundation-models-utilities history modifier source: RollingWindow uses history.suffix(numberOfEntries); DropCompletedToolCalls removes toolCalls/toolOutput before the latest response/toolCalls boundary.
- Apple's package itself targets OS 27+, so it is only a behavior reference here, not a dependency or compatibility baseline.

Verification

- swift test with default Xcode 26.5 beta: 54 tests passed
- DEVELOPER_DIR=/Applications/Xcode-26.3.0.app/Contents/Developer swift test: 54 tests passed
