### PR TITLE
Add transcript summarization helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,7 @@ FoundationModelsTools provides comprehensive token counting and context window m
 - `entriesWithinTokenBudget(_:)` - Sliding window implementation for long conversations
 - `rollingWindow(entries:)` - Keep the most recent transcript entries by count
 - `droppingCompletedToolCalls()` - Remove older completed tool-call exchanges
+- `summarizingHistory(entryThreshold:summaryPostamble:summarize:)` - Collapse older history into a summary prompt when a conversation grows past a threshold
 
 #### Basic Token Counting
 
@@ -674,10 +675,24 @@ FoundationModelsTools provides comprehensive token counting and context window m
 import FoundationModels
 import FoundationModelsTools
 
-let transcript = Transcript([
-    .instructions("You are a helpful assistant"),
-    .prompt("What's the weather like?"),
-    .response("The weather is sunny and 72°F")
+let transcript = Transcript(entries: [
+    .instructions(
+        Transcript.Instructions(
+            segments: [.text(Transcript.TextSegment(content: "You are a helpful assistant"))],
+            toolDefinitions: []
+        )
+    ),
+    .prompt(
+        Transcript.Prompt(
+            segments: [.text(Transcript.TextSegment(content: "What's the weather like?"))]
+        )
+    ),
+    .response(
+        Transcript.Response(
+            assetIDs: [],
+            segments: [.text(Transcript.TextSegment(content: "The weather is sunny and 72°F"))]
+        )
+    )
 ])
 
 // Get token estimate
@@ -710,7 +725,7 @@ When conversations exceed token limits, use `entriesWithinTokenBudget(_:)` to ma
 ```swift
 let maxTokens = 2000
 let trimmedEntries = transcript.entriesWithinTokenBudget(maxTokens)
-let newTranscript = Transcript(trimmedEntries)
+let newTranscript = Transcript(entries: trimmedEntries)
 
 // The trimmed transcript:
 // - Includes the first instructions entry if it fits within the budget
@@ -720,15 +735,38 @@ let newTranscript = Transcript(trimmedEntries)
 
 ### Transcript History Transforms
 
-Use entry-level history transforms when you want lightweight transcript cleanup before building the next session or prompt history.
+Use entry-level history transforms when you want lightweight transcript cleanup before building the next session or prompt history. These helpers work with `Transcript.Entry` collections directly, so you can use them before creating a new `Transcript` or `LanguageModelSession`.
 
 ```swift
 let compactEntries = transcript
     .droppingCompletedToolCalls()
     .rollingWindow(entries: 10)
+
+let compactTranscript = Transcript(entries: compactEntries)
 ```
 
 `rollingWindow(entries:)` keeps the latest entries exactly by count. `droppingCompletedToolCalls()` removes older tool-call and tool-output entries while preserving the latest active tool exchange and all non-tool entries.
+
+For longer conversations, use `summarizingHistory(entryThreshold:summaryPostamble:summarize:)` to replace earlier history with a single summary block attached to the latest prompt. The summarizer is a closure, so you can use the on-device Foundation Models session, a server model, or a deterministic test double.
+
+```swift
+let summarizer = LanguageModelSession(instructions: """
+Compress the conversation into concise facts, decisions, preferences, \
+and unresolved questions. Preserve the latest active thread.
+""")
+
+let summarizedEntries = try await transcript
+    .droppingCompletedToolCalls()
+    .summarizingHistory(entryThreshold: 24) { prompt in
+        try await summarizer.respond(to: prompt).content
+    }
+
+let nextSession = LanguageModelSession(
+    transcript: Transcript(entries: summarizedEntries)
+)
+```
+
+Summarization only runs when the entry count is above the threshold and the latest entry is a prompt. If the latest entry is a tool output or the transcript is still small, the original entries are returned unchanged.
 
 #### Token Estimation Functions
 
@@ -752,41 +790,30 @@ print("Content tokens: \(contentTokens)")
 3. **Preserve Instructions:** The sliding window attempts to keep the first system instructions entry for consistency, provided it fits within the token budget
 4. **Monitor Long Conversations:** Check token counts periodically in chat applications
 
-#### Example: Chat with Token Management
+#### Example: Preparing History for a New Session
 
 ```swift
 import FoundationModels
 import FoundationModelsTools
 
-class ChatManager {
-    private var transcript = Transcript()
-    private let maxTokens = 4096
-    private let threshold = 0.7
+func preparedTranscript(
+    from transcript: Transcript,
+    maxTokens: Int = 4096,
+    summarizer: LanguageModelSession
+) async throws -> Transcript {
+    var entries = Array(transcript)
 
-    init(systemInstructions: String) {
-        transcript = Transcript([.instructions(systemInstructions)])
+    if transcript.isApproachingLimit(threshold: 0.7, maxTokens: maxTokens) {
+        entries = transcript.entriesWithinTokenBudget(Int(Double(maxTokens) * 0.6))
     }
 
-    func addMessage(_ message: String) async throws -> String {
-        // Add user message
-        transcript.append(.prompt(message))
-
-        // Check if we're approaching the limit
-        if transcript.isApproachingLimit(threshold: threshold, maxTokens: maxTokens) {
-            // Trim to fit budget (leaving room for response)
-            let budget = Int(Double(maxTokens) * 0.6) // Use 60% for history
-            let trimmedEntries = transcript.entriesWithinTokenBudget(budget)
-            transcript = Transcript(trimmedEntries)
-            print("Trimmed transcript to \(transcript.estimatedTokenCount) tokens")
+    entries = try await entries
+        .droppingCompletedToolCalls()
+        .summarizingHistory(entryThreshold: 24) { prompt in
+            try await summarizer.respond(to: prompt).content
         }
 
-        // Generate response with managed context
-        let session = LanguageModelSession(model: .instant)
-        let response = try await session.generate(from: transcript)
-        transcript.append(.response(response))
-
-        return response.text
-    }
+    return Transcript(entries: entries)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ let compactTranscript = Transcript(entries: compactEntries)
 
 `rollingWindow(entries:)` keeps the latest entries exactly by count. `droppingCompletedToolCalls()` removes older tool-call and tool-output entries while preserving the latest active tool exchange and all non-tool entries.
 
-For longer conversations, use `summarizingHistory(entryThreshold:summaryPostamble:summarize:)` to replace earlier history with a single summary block attached to the latest prompt. The summarizer is a closure, so you can use the on-device Foundation Models session, a server model, or a deterministic test double.
+For longer conversations, use `summarizingHistory(entryThreshold:summaryPostamble:summarize:)` to replace earlier conversational history with a single summary block attached to the latest prompt. Instruction entries are preserved, including tool definitions. The summarizer is a closure, so you can use the on-device Foundation Models session, a server model, or a deterministic test double.
 
 ```swift
 let summarizer = LanguageModelSession(instructions: """

--- a/Sources/Extensions/Transcript+HistoryTransforms.swift
+++ b/Sources/Extensions/Transcript+HistoryTransforms.swift
@@ -53,4 +53,114 @@ extension Collection where Element == Transcript.Entry {
     let suffix = entries[lastOutputIndex...]
     return Array(prefix + suffix)
   }
+
+  /// Returns transcript entries with earlier history summarized into the latest prompt.
+  ///
+  /// The helper summarizes only when the collection has more entries than
+  /// `entryThreshold` and the latest entry is a prompt. Otherwise, the original
+  /// entries are returned unchanged.
+  ///
+  /// When summarization runs, the returned history contains a single prompt. The
+  /// prompt starts with a text segment containing the generated summary and
+  /// optional postamble, followed by the latest prompt's original segments,
+  /// options, and response format.
+  ///
+  /// - Parameters:
+  ///   - entryThreshold: Summarize only when the entry count is greater than this value.
+  ///   - summaryPostamble: Text appended after the summary. Pass an empty string
+  ///     to omit the postamble. Pass `nil` to use the default postamble.
+  ///   - summarize: A closure that receives a summarization prompt and returns
+  ///     the summary text.
+  /// - Returns: The summarized entries, or the original entries when the
+  ///   threshold is not exceeded or the latest entry is not a prompt.
+  public func summarizingHistory(
+    entryThreshold: Int,
+    summaryPostamble: String? = nil,
+    summarize: (String) async throws -> String
+  ) async rethrows -> [Transcript.Entry] {
+    let entries = Array(self)
+
+    guard entries.count > entryThreshold else {
+      return entries
+    }
+
+    guard case .prompt(let prompt) = entries.last else {
+      return entries
+    }
+
+    let summary = try await summarize(transcriptSummaryPrompt(for: entries.chatLog()))
+    let postamble = summaryPostamble ?? defaultTranscriptSummaryPostamble
+    var summaryContent = """
+      Summary of the conversation so far:
+      \(summary)
+      """
+
+    if !postamble.isEmpty {
+      summaryContent += "\n\n\(postamble)"
+    }
+
+    summaryContent += "\n\n"
+
+    let summarySegment = Transcript.TextSegment(content: summaryContent)
+    let summarizedPrompt = Transcript.Prompt(
+      segments: [.text(summarySegment)] + prompt.segments,
+      options: prompt.options,
+      responseFormat: prompt.responseFormat
+    )
+
+    return [.prompt(summarizedPrompt)]
+  }
+}
+
+private let defaultTranscriptSummaryPostamble = """
+  Do not begin with phrases like "Based on the context", "Based on the facts", \
+  "Based on the summary", or any reference to a summary or the facts provided. \
+  Treat the summary and facts above as things you naturally remember.
+  """
+
+private func transcriptSummaryPrompt(for chatLog: String) -> String {
+  "Summarize this conversation:\n\n\(chatLog)"
+}
+
+private extension Sequence where Element == Transcript.Entry {
+  func chatLog(separator: String = "\n") -> String {
+    compactMap(\.chatText).joined(separator: separator)
+  }
+}
+
+private extension Transcript.Entry {
+  var chatText: String? {
+    if case .prompt(let prompt) = self {
+      return "User: \(prompt.segments.textContent)"
+    }
+
+    if case .response(let response) = self {
+      return "Assistant: \(response.segments.textContent)"
+    }
+
+    if case .toolCalls(let calls) = self {
+      let renderedCalls = calls
+        .map { "\($0.toolName)(\($0.arguments))" }
+        .joined(separator: ", ")
+      return "Tool call: \(renderedCalls)"
+    }
+
+    if case .toolOutput(let output) = self {
+      return "Tool output (\(output.toolName)): \(output.segments.textContent)"
+    }
+
+    return nil
+  }
+}
+
+private extension Sequence where Element == Transcript.Segment {
+  var textContent: String {
+    compactMap { segment in
+      if case .text(let textSegment) = segment {
+        return textSegment.content
+      }
+      return nil
+    }
+    .joined(separator: " ")
+  }
 }

--- a/Sources/Extensions/Transcript+HistoryTransforms.swift
+++ b/Sources/Extensions/Transcript+HistoryTransforms.swift
@@ -60,10 +60,10 @@ extension Collection where Element == Transcript.Entry {
   /// `entryThreshold` and the latest entry is a prompt. Otherwise, the original
   /// entries are returned unchanged.
   ///
-  /// When summarization runs, the returned history contains a single prompt. The
-  /// prompt starts with a text segment containing the generated summary and
-  /// optional postamble, followed by the latest prompt's original segments,
-  /// options, and response format.
+  /// When summarization runs, the returned history preserves instruction
+  /// entries, then adds a single prompt. The prompt starts with a text segment
+  /// containing the generated summary and optional postamble, followed by the
+  /// latest prompt's original segments, options, and response format.
   ///
   /// - Parameters:
   ///   - entryThreshold: Summarize only when the entry count is greater than this value.
@@ -108,7 +108,12 @@ extension Collection where Element == Transcript.Entry {
       responseFormat: prompt.responseFormat
     )
 
-    return [.prompt(summarizedPrompt)]
+    let instructions = entries.filter { entry in
+      if case .instructions = entry { return true }
+      return false
+    }
+
+    return instructions + [.prompt(summarizedPrompt)]
   }
 }
 

--- a/Sources/Extensions/Transcript+TokenCounting.swift
+++ b/Sources/Extensions/Transcript+TokenCounting.swift
@@ -182,7 +182,7 @@ extension Transcript {
   /// ```swift
   /// let transcript = Transcript(...)
   /// let trimmed = transcript.entriesWithinTokenBudget(2000)
-  /// let newTranscript = Transcript(trimmed)
+  /// let newTranscript = Transcript(entries: trimmed)
   /// ```
   public func entriesWithinTokenBudget(_ budget: Int) -> [Transcript.Entry] {
     var tokenCount = 0

--- a/Tests/FoundationModelsToolsTests/TokenCountingTests.swift
+++ b/Tests/FoundationModelsToolsTests/TokenCountingTests.swift
@@ -262,6 +262,143 @@ struct TranscriptHistoryTransformTests {
       "Second",
     ])
   }
+
+  @Test("Summarizing history preserves entries when under threshold")
+  func summarizingHistoryPreservesEntriesWhenUnderThreshold() async throws {
+    let entries: [Transcript.Entry] = [
+      .prompt(.foundationModelsTools("First")),
+      .toolOutput(.foundationModelsTools(id: "first-output", text: "First answer")),
+    ]
+
+    let summarized = await entries.summarizingHistory(entryThreshold: 10) { _ in
+      Issue.record("Summarizer should not be called under threshold")
+      return "Unused"
+    }
+
+    #expect(summarized == entries)
+  }
+
+  @Test("Summarizing history preserves entries when latest entry is not a prompt")
+  func summarizingHistoryPreservesEntriesWhenLatestEntryIsNotPrompt() async throws {
+    let entries: [Transcript.Entry] = [
+      .prompt(.foundationModelsTools("First")),
+      .toolOutput(.foundationModelsTools(id: "first-output", text: "First answer")),
+    ]
+
+    let summarized = await entries.summarizingHistory(entryThreshold: 1) { _ in
+      Issue.record("Summarizer should not be called unless the latest entry is a prompt")
+      return "Unused"
+    }
+
+    #expect(summarized == entries)
+  }
+
+  @Test("Summarizing history collapses prior entries into latest prompt")
+  func summarizingHistoryCollapsesPriorEntriesIntoLatestPrompt() async throws {
+    let entries: [Transcript.Entry] = [
+      .instructions(.foundationModelsTools("System")),
+      .prompt(.foundationModelsTools("First topic.")),
+      .toolOutput(.foundationModelsTools(id: "first-output", text: "First answer.")),
+      .prompt(.foundationModelsTools("Second topic.")),
+    ]
+
+    var receivedPrompt = ""
+    let summarized = await entries.summarizingHistory(entryThreshold: 2) { prompt in
+      receivedPrompt = prompt
+      return "User asked about the first topic."
+    }
+
+    #expect(receivedPrompt == """
+      Summarize this conversation:
+
+      User: First topic.
+      Tool output (testTool): First answer.
+      User: Second topic.
+      """)
+    #expect(summarized.count == 1)
+    #expect(summarized.first?.foundationModelsToolsText == """
+      Summary of the conversation so far:
+      User asked about the first topic.
+
+      Do not begin with phrases like "Based on the context", "Based on the facts", "Based on the summary", or any reference to a summary or the facts provided. Treat the summary and facts above as things you naturally remember.
+
+      Second topic.
+      """)
+  }
+
+  @Test("Summarizing history uses custom postamble")
+  func summarizingHistoryUsesCustomPostamble() async throws {
+    let entries: [Transcript.Entry] = [
+      .prompt(.foundationModelsTools("First topic.")),
+      .prompt(.foundationModelsTools("Second topic.")),
+    ]
+
+    let summarized = await entries.summarizingHistory(
+      entryThreshold: 1,
+      summaryPostamble: "Continue naturally."
+    ) { _ in
+      "The user is discussing two topics."
+    }
+
+    #expect(summarized.first?.foundationModelsToolsText == """
+      Summary of the conversation so far:
+      The user is discussing two topics.
+
+      Continue naturally.
+
+      Second topic.
+      """)
+  }
+
+  @Test("Summarizing history omits empty postamble")
+  func summarizingHistoryOmitsEmptyPostamble() async throws {
+    let entries: [Transcript.Entry] = [
+      .prompt(.foundationModelsTools("First topic.")),
+      .prompt(.foundationModelsTools("Second topic.")),
+    ]
+
+    let summarized = await entries.summarizingHistory(
+      entryThreshold: 1,
+      summaryPostamble: ""
+    ) { _ in
+      "The user is discussing two topics."
+    }
+
+    #expect(summarized.first?.foundationModelsToolsText == """
+      Summary of the conversation so far:
+      The user is discussing two topics.
+
+      Second topic.
+      """)
+  }
+
+  @Test("Summarizing history preserves latest prompt options and response format")
+  func summarizingHistoryPreservesLatestPromptOptionsAndResponseFormat() async throws {
+    let responseFormat = Transcript.ResponseFormat(
+      schema: GenerationSchema(type: String.self, properties: [])
+    )
+    let latestPrompt = Transcript.Prompt(
+      segments: [.text(Transcript.TextSegment(content: "Second topic."))],
+      options: GenerationOptions(temperature: 0.3),
+      responseFormat: responseFormat
+    )
+    let entries: [Transcript.Entry] = [
+      .prompt(.foundationModelsTools("First topic.")),
+      .prompt(latestPrompt),
+    ]
+
+    let summarized = await entries.summarizingHistory(entryThreshold: 1) { _ in
+      "The user is discussing two topics."
+    }
+
+    guard case .prompt(let prompt) = summarized.first else {
+      Issue.record("Expected summarized history to contain a prompt")
+      return
+    }
+
+    #expect(prompt.options == latestPrompt.options)
+    #expect(prompt.responseFormat == latestPrompt.responseFormat)
+  }
 }
 
 private extension Transcript.Entry {
@@ -301,7 +438,7 @@ private extension [Transcript.Segment] {
         return text.content
       }
       return nil
-    }.joined(separator: "\n")
+    }.joined()
   }
 }
 

--- a/Tests/FoundationModelsToolsTests/TokenCountingTests.swift
+++ b/Tests/FoundationModelsToolsTests/TokenCountingTests.swift
@@ -315,8 +315,12 @@ struct TranscriptHistoryTransformTests {
       Tool output (testTool): First answer.
       User: Second topic.
       """)
-    #expect(summarized.count == 1)
-    #expect(summarized.first?.foundationModelsToolsText == """
+    #expect(summarized.count == 2)
+    #expect(summarized.map { $0.foundationModelsToolsKind } == [
+      "instructions",
+      "prompt",
+    ])
+    #expect(summarized.last?.foundationModelsToolsText == """
       Summary of the conversation so far:
       User asked about the first topic.
 
@@ -324,6 +328,36 @@ struct TranscriptHistoryTransformTests {
 
       Second topic.
       """)
+  }
+
+  @Test("Summarizing history preserves instruction tool definitions")
+  func summarizingHistoryPreservesInstructionToolDefinitions() async throws {
+    let toolDefinition = Transcript.ToolDefinition(
+      name: "search",
+      description: "Searches documents",
+      parameters: GenerationSchema(type: String.self, properties: [])
+    )
+    let instructions = Transcript.Instructions(
+      segments: [.text(Transcript.TextSegment(content: "Use tools carefully."))],
+      toolDefinitions: [toolDefinition]
+    )
+    let entries: [Transcript.Entry] = [
+      .instructions(instructions),
+      .prompt(.foundationModelsTools("First topic.")),
+      .prompt(.foundationModelsTools("Second topic.")),
+    ]
+
+    let summarized = await entries.summarizingHistory(entryThreshold: 1) { _ in
+      "The user is discussing two topics."
+    }
+
+    guard case .instructions(let preservedInstructions) = summarized.first else {
+      Issue.record("Expected summarized history to preserve instructions")
+      return
+    }
+
+    #expect(preservedInstructions == instructions)
+    #expect(preservedInstructions.toolDefinitions == [toolDefinition])
   }
 
   @Test("Summarizing history uses custom postamble")


### PR DESCRIPTION
Summary

- add summarizingHistory(entryThreshold:summaryPostamble:summarize:) for OS 26-compatible transcript history compaction
- render transcript entries into a summarizer prompt and collapse earlier conversational history into the latest prompt
- preserve instruction entries, tool definitions, latest prompt segments, options, and response format when summarizing
- document summarization usage with a closure-based Foundation Models example
- polish README transcript examples to use explicit Transcript(entries:) construction

Compatibility

- Intentionally avoids OS 27-only APIs such as DynamicProfile, new transcript cases, attachments, or custom segments.
- The summarizer is a closure so callers can use Foundation Models, a server model, or a test double without adding a new runtime dependency.

Verification

- swift package clean && swift test with default Xcode 26.5 beta: 61 tests passed
- DEVELOPER_DIR=/Applications/Xcode-26.3.0.app/Contents/Developer swift package clean && DEVELOPER_DIR=/Applications/Xcode-26.3.0.app/Contents/Developer swift test: 61 tests passed
