### PR TITLE
Document active package development in Foundation Lab

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,73 @@
+# Migration to Foundation Models Framework Lab
+
+FoundationModelsKit 2.x remains published from this repository. Active package
+development now happens in
+[Foundation Models Framework Lab](https://github.com/rudrankriyam/Foundation-Models-Framework-Lab)
+so the app, command-line tools, evaluations, and reusable utilities share one
+tested implementation.
+
+## Who Needs To Migrate
+
+No migration is required for applications pinned to a 2.x release. Existing
+tags and the `FoundationModelsTools` product remain available here.
+
+Move to the Lab dependency when you want the current transcript utilities,
+context-budget fixes, history transforms, and tool updates.
+
+## Package Dependency
+
+Replace the standalone dependency:
+
+```swift
+.package(
+    url: "https://github.com/rryam/FoundationModelsKit",
+    from: "2.0.0"
+)
+```
+
+with the active Lab package:
+
+```swift
+.package(
+    url: "https://github.com/rudrankriyam/Foundation-Models-Framework-Lab.git",
+    branch: "main"
+)
+```
+
+## Products
+
+The Lab package exposes two products:
+
+```swift
+.target(
+    name: "YourTarget",
+    dependencies: [
+        .product(
+            name: "FoundationModelsKit",
+            package: "foundation-models-framework-lab"
+        ),
+        .product(
+            name: "FoundationModelsTools",
+            package: "foundation-models-framework-lab"
+        )
+    ]
+)
+```
+
+- `FoundationModelsKit` contains lightweight transcript, token-counting,
+  context-budget, text-content, and history-transform utilities.
+- `FoundationModelsTools` contains the system and web tools and re-exports
+  `FoundationModelsKit`.
+
+Existing code that imports only `FoundationModelsTools` remains source
+compatible. Add a direct `FoundationModelsKit` product dependency when an app
+wants the lightweight utilities without permission-heavy system tools.
+
+## Source And Issues
+
+- Active source:
+  [`Packages/FoundationModelsKit`](https://github.com/rudrankriyam/Foundation-Models-Framework-Lab/tree/main/Packages/FoundationModelsKit)
+- Active issues:
+  [Foundation Models Framework Lab issues](https://github.com/rudrankriyam/Foundation-Models-Framework-Lab/issues)
+- Stable 2.x releases:
+  [FoundationModelsKit releases](https://github.com/rryam/FoundationModelsKit/releases)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # FoundationModelsKit
 
+> [!IMPORTANT]
+> Versioned 2.x releases remain available from this repository and existing
+> dependencies continue to resolve unchanged. Active development now lives in
+> [Foundation Models Framework Lab](https://github.com/rudrankriyam/Foundation-Models-Framework-Lab/tree/main/Packages/FoundationModelsKit),
+> which publishes the `FoundationModelsKit` and `FoundationModelsTools` products.
+> See [MIGRATION.md](MIGRATION.md) for the package switch and compatibility notes.
 
 A collection of tools and utilities for Apple's Foundation Models Framework that help working with the language model, better.
 
@@ -9,6 +15,7 @@ A collection of tools and utilities for Apple's Foundation Models Framework that
 - [Features](#features)
 - [Requirements](#requirements)
 - [Installation](#installation)
+- [Migration to Foundation Lab](MIGRATION.md)
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
   - [Privacy Permissions](#privacy-permissions)
@@ -70,21 +77,49 @@ A collection of tools and utilities for Apple's Foundation Models Framework that
 
 ## Installation
 
-Add **FoundationModelsTools** as a dependency in your `Package.swift`:
+### Active Package
+
+For current development, add Foundation Models Framework Lab as a dependency:
+
+```swift
+dependencies: [
+    .package(
+        url: "https://github.com/rudrankriyam/Foundation-Models-Framework-Lab.git",
+        branch: "main"
+    )
+]
+```
+
+Choose the lightweight utilities, system tools, or both:
+
+```swift
+.target(
+    name: "YourTarget",
+    dependencies: [
+        .product(
+            name: "FoundationModelsKit",
+            package: "foundation-models-framework-lab"
+        ),
+        .product(
+            name: "FoundationModelsTools",
+            package: "foundation-models-framework-lab"
+        )
+    ]
+)
+```
+
+`FoundationModelsTools` re-exports `FoundationModelsKit`, so existing source files
+that only import `FoundationModelsTools` remain compatible.
+
+### Stable 2.x
+
+Applications that prefer the versioned 2.x package can continue using this
+repository without code changes:
 
 ```swift
 dependencies: [
     .package(url: "https://github.com/rryam/FoundationModelsKit", from: "2.0.0")
 ]
-```
-
-Then add it to your target dependencies:
-
-```swift
-.target(
-    name: "YourTarget",
-    dependencies: ["FoundationModelsTools"]
-)
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- keep the existing 2.x dependency and release path documented as stable and unchanged
- point active package development to `Packages/FoundationModelsKit` in Foundation Models Framework Lab
- document both public Lab products and the source-compatible `FoundationModelsTools` path
- add a focused migration guide for consumers that want the current utilities and fixes

## Compatibility

This repository remains public and unarchived. Existing 2.x tags and dependencies are unchanged; no migration is required for pinned applications.

## Validation

- standalone `Package.swift` still dumps successfully
- Lab package paths and issue links verified through GitHub
- published 2.0.0 release verified
- a clean external SwiftPM consumer resolved Lab `main`, built in release mode, and used both `FoundationModelsKit` and `FoundationModelsTools`
- `git diff --check`

## Merge policy

Use a regular merge commit. Do not squash or rebase-merge this PR.