### PR TITLE
Add Foundation Models agent skills

### DIFF
--- a/skills/foundation-models-app-builder/SKILL.md
+++ b/skills/foundation-models-app-builder/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: foundation-models-app-builder
+description: Build or modify Apple Foundation Models features in Swift, SwiftUI, iOS, and macOS apps. Use when adding or reviewing LanguageModelSession flows, model availability checks, streaming, GenerationOptions, @Generable structured output, DynamicGenerationSchema, tool calling, RAG, voice input/output, HealthKit-backed AI, multilingual responses, App Intents, reusable capability boundaries, or production error handling.
+---
+
+# Foundation Models App Builder
+
+Use this skill as a self-contained Foundation Models app-building playbook. The recipes live inside this skill so agents can apply the patterns in any Swift app without needing to inspect a particular app repository.
+
+## What This Skill Optimizes For
+
+- Shipping app features, not reciting API docs.
+- Turning Foundation Models into reusable app capabilities with clear Swift types.
+- Keeping model orchestration separate from SwiftUI, App Intents, permissions, and persistence.
+- Choosing the smallest useful pattern: text, structured output, dynamic schema, tool, RAG, voice, or domain-specific integration.
+- Leaving every feature with availability handling, cancellation, recovery, and verification.
+
+## Workflow
+
+1. Identify the feature shape: availability, one-shot text, streaming, structured output, dynamic schema, tool calling, RAG, voice, HealthKit, multilingual, App Intent, or reusable capability extraction.
+2. Load only the reference file for that feature.
+3. Start from the packaged Swift recipe, then adapt naming, UI, permissions, and domain models to the target app.
+4. Keep reusable Foundation Models orchestration out of SwiftUI views when the feature will be shared by app screens, App Intents, CLI commands, widgets, or tests.
+5. Add graceful fallback behavior for unavailable Apple Intelligence, unsupported languages, denied permissions, context-window overflow, rate limits, decoding failures, and guardrail refusals.
+6. Verify with the narrowest build or test command that covers the changed surface.
+
+## Reference Routing
+
+- **Reusable app architecture, providers, use cases, SwiftUI adapters**: `references/architecture.md`
+- **Availability, sessions, instructions, generation options, streaming, prewarming**: `references/availability-and-sessions.md`
+- **Compile-time structured output with `@Generable` and `@Guide`**: `references/structured-generation.md`
+- **Runtime schemas with `DynamicGenerationSchema` and `GeneratedContent`**: `references/dynamic-schemas.md`
+- **Foundation Models tools and permission-aware app integrations**: `references/tool-calling.md`
+- **Retrieval-augmented generation and grounded prompts**: `references/rag.md`
+- **Speech recognition, text-to-speech, and voice state machines**: `references/voice.md`
+- **App Intents backed by shared Foundation Models capabilities**: `references/app-intents.md`
+- **HealthKit-backed AI features and safety wording**: `references/healthkit.md`
+- **Supported languages, language selection, and code switching**: `references/multilingual.md`
+- **Generation errors, guardrails, retries, and verification checks**: `references/common-errors.md`
+
+## Core Rules
+
+- Use `@Generable` when the output type is known at compile time.
+- Use `DynamicGenerationSchema` only when the schema is built at runtime.
+- Create a fresh `LanguageModelSession` for unrelated one-shot tasks; keep a session only when conversation memory matters.
+- Put permissions and user confirmation at app boundaries, not inside model prompts.
+- Keep streaming UI updates cancellable and main-actor safe.
+- Avoid App Intent-only prompt logic. Shared tasks should be callable from the app UI too.
+- Prefer compact, domain-specific instructions over giant prompts.
+- Do not assume Foundation Models are available; check `SystemLanguageModel.default.availability`.
+
+## Feature Contract
+
+When adding a Foundation Models feature, aim to leave behind these pieces:
+
+- a Swift type that names the task input
+- a Swift type that names the task output
+- a small generation provider or use case
+- a UI, App Intent, or service adapter that calls the use case
+- a model-unavailable path
+- a cancellation path for streaming or long-running work
+- a user-facing recovery path for generation errors
+- a narrow verification command or manual check

--- a/skills/foundation-models-app-builder/agents/openai.yaml
+++ b/skills/foundation-models-app-builder/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Foundation Models App Builder"
+  short_description: "Build Foundation Models features with packaged Swift recipes."
+  default_prompt: "Use the packaged Foundation Models recipes to add or improve a Swift app feature."

--- a/skills/foundation-models-app-builder/references/app-intents.md
+++ b/skills/foundation-models-app-builder/references/app-intents.md
@@ -1,0 +1,78 @@
+# App Intents
+
+Use this reference when exposing Foundation Models features to Shortcuts, Spotlight, Siri, controls, or app shortcuts.
+
+App Intents should be thin adapters over shared capabilities. Avoid duplicating prompt orchestration in intent files when the same feature exists in the app UI.
+
+## Intent Over Shared Use Case
+
+```swift
+import AppIntents
+
+struct SummarizeNotesIntent: AppIntent {
+    static let title: LocalizedStringResource = "Summarize Notes"
+    static let description = IntentDescription("Summarizes notes with on-device Foundation Models.")
+
+    @Parameter(title: "Notes")
+    var notes: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await GenerateSummaryUseCase().execute(notes: notes)
+        return .result(value: result.content)
+    }
+}
+```
+
+## Direct Intent For Small Features
+
+For a tiny one-off intent, keep the model call compact and move it into a use case later if the app UI also needs it.
+
+```swift
+import AppIntents
+import FoundationModels
+
+struct GenerateLocalizedResponseIntent: AppIntent {
+    static let title: LocalizedStringResource = "Generate Localized Response"
+
+    @Parameter(title: "Prompt")
+    var prompt: String
+
+    @Parameter(title: "Language")
+    var language: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let session = LanguageModelSession(
+            instructions: Instructions("Respond in \(language).")
+        )
+        let response = try await session.respond(to: Prompt(prompt))
+        return .result(value: response.content)
+    }
+}
+```
+
+## App Shortcut
+
+```swift
+struct FoundationModelsShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: SummarizeNotesIntent(),
+            phrases: [
+                "Summarize notes with \(.applicationName)",
+                "Use \(.applicationName) to summarize notes"
+            ],
+            shortTitle: "Summarize Notes",
+            systemImageName: "sparkles"
+        )
+    }
+}
+```
+
+## Intent Checklist
+
+- Keep parameters small and clear.
+- Return concise values for Siri and Shortcuts.
+- Validate empty input before model generation.
+- Avoid long-running multi-turn sessions in intents.
+- Use shared use cases for tasks also available in SwiftUI.
+- For write actions, return a draft or ask for confirmation before committing data.

--- a/skills/foundation-models-app-builder/references/architecture.md
+++ b/skills/foundation-models-app-builder/references/architecture.md
@@ -1,0 +1,213 @@
+# Architecture Recipes
+
+Use these patterns when a Foundation Models feature should be reusable across SwiftUI, App Intents, CLI commands, widgets, or tests.
+
+## Shared Text Capability
+
+```swift
+import Foundation
+import FoundationModels
+
+public struct TextGenerationRequest: Sendable, Hashable {
+    public var prompt: String
+    public var systemPrompt: String?
+    public var options: GenerationOptions?
+
+    public init(prompt: String, systemPrompt: String? = nil, options: GenerationOptions? = nil) {
+        self.prompt = prompt
+        self.systemPrompt = systemPrompt
+        self.options = options
+    }
+}
+
+public struct TextGenerationResult: Sendable, Hashable {
+    public var content: String
+    public var estimatedTokenCount: Int?
+}
+
+public protocol TextGenerating: Sendable {
+    func generateText(for request: TextGenerationRequest) async throws -> TextGenerationResult
+}
+
+public struct FoundationModelsTextGenerator: TextGenerating {
+    public init() {}
+
+    public func generateText(for request: TextGenerationRequest) async throws -> TextGenerationResult {
+        let prompt = request.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw AppAIError.invalidPrompt
+        }
+
+        let model = SystemLanguageModel.default
+        let session: LanguageModelSession
+
+        if let systemPrompt = request.systemPrompt?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !systemPrompt.isEmpty {
+            session = LanguageModelSession(
+                model: model,
+                instructions: Instructions(systemPrompt)
+            )
+        } else {
+            session = LanguageModelSession(model: model)
+        }
+
+        let content: String
+        if let options = request.options {
+            content = try await session.respond(to: Prompt(prompt), options: options).content
+        } else {
+            content = try await session.respond(to: Prompt(prompt)).content
+        }
+
+        return TextGenerationResult(
+            content: content,
+            estimatedTokenCount: session.transcript.estimatedTokenCount
+        )
+    }
+}
+```
+
+## Use Case Wrapper
+
+```swift
+public struct GenerateSummaryUseCase: Sendable {
+    private let generator: any TextGenerating
+
+    public init(generator: any TextGenerating = FoundationModelsTextGenerator()) {
+        self.generator = generator
+    }
+
+    public func execute(notes: String) async throws -> TextGenerationResult {
+        try await generator.generateText(
+            for: TextGenerationRequest(
+                prompt: notes,
+                systemPrompt: "Summarize the notes into three concise bullets.",
+                options: GenerationOptions(temperature: 0.2, maximumResponseTokens: 180)
+            )
+        )
+    }
+}
+```
+
+## SwiftUI Adapter
+
+```swift
+import Observation
+import SwiftUI
+
+@MainActor
+@Observable
+final class SummaryViewModel {
+    var input = ""
+    var output = ""
+    var isGenerating = false
+    var errorMessage: String?
+
+    private let useCase: GenerateSummaryUseCase
+    private var task: Task<Void, Never>?
+
+    init(useCase: GenerateSummaryUseCase = GenerateSummaryUseCase()) {
+        self.useCase = useCase
+    }
+
+    func generate() {
+        task?.cancel()
+        isGenerating = true
+        errorMessage = nil
+
+        task = Task {
+            do {
+                let result = try await useCase.execute(notes: input)
+                guard !Task.isCancelled else { return }
+                output = result.content
+            } catch {
+                guard !Task.isCancelled else { return }
+                errorMessage = AppAIError.userMessage(for: error)
+            }
+
+            isGenerating = false
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+        isGenerating = false
+    }
+}
+```
+
+## App Intent Adapter
+
+```swift
+import AppIntents
+
+struct SummarizeNotesIntent: AppIntent {
+    static let title: LocalizedStringResource = "Summarize Notes"
+
+    @Parameter(title: "Notes")
+    var notes: String
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> {
+        let result = try await GenerateSummaryUseCase().execute(notes: notes)
+        return .result(value: result.content)
+    }
+}
+```
+
+## Shared Error Mapping
+
+```swift
+enum AppAIError: Error, LocalizedError {
+    case invalidPrompt
+    case modelUnavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidPrompt:
+            "Enter a prompt before generating."
+        case .modelUnavailable(let reason):
+            "Apple Intelligence is not available: \(reason)"
+        }
+    }
+
+    static func userMessage(for error: Error) -> String {
+        switch error {
+        case LanguageModelSession.GenerationError.exceededContextWindowSize:
+            "This conversation is too long. Start a new chat or remove earlier messages."
+        case LanguageModelSession.GenerationError.guardrailViolation:
+            "The request was blocked by the safety system."
+        case LanguageModelSession.GenerationError.assetsUnavailable:
+            "Foundation Models are temporarily unavailable."
+        case LanguageModelSession.GenerationError.concurrentRequests:
+            "Wait for the current response to finish."
+        case LanguageModelSession.GenerationError.rateLimited:
+            "Too many requests. Try again in a moment."
+        case LanguageModelSession.GenerationError.unsupportedLanguageOrLocale:
+            "This language or locale is not supported."
+        case LanguageModelSession.GenerationError.decodingFailure:
+            "The response could not be decoded. Try simplifying the request."
+        case LanguageModelSession.GenerationError.unsupportedGuide:
+            "One of the generation guides is not supported."
+        case LanguageModelSession.GenerationError.refusal(_, _):
+            "The model declined to respond."
+        default:
+            error.localizedDescription
+        }
+    }
+}
+```
+
+## Token Estimate Helper
+
+Use real token counting when available in the deployment target; otherwise keep a conservative fallback.
+
+```swift
+import FoundationModels
+
+extension Transcript {
+    var estimatedTokenCount: Int {
+        reduce(0) { partial, entry in
+            partial + String(describing: entry).count / 4 + 1
+        }
+    }
+}
+```

--- a/skills/foundation-models-app-builder/references/architecture.md
+++ b/skills/foundation-models-app-builder/references/architecture.md
@@ -39,6 +39,10 @@ public struct FoundationModelsTextGenerator: TextGenerating {
         }
 
         let model = SystemLanguageModel.default
+        guard case .available = model.availability else {
+            throw AppAIError.modelUnavailable(String(describing: model.availability))
+        }
+
         let session: LanguageModelSession
 
         if let systemPrompt = request.systemPrompt?.trimmingCharacters(in: .whitespacesAndNewlines),

--- a/skills/foundation-models-app-builder/references/architecture.md
+++ b/skills/foundation-models-app-builder/references/architecture.md
@@ -119,16 +119,18 @@ final class SummaryViewModel {
         errorMessage = nil
 
         task = Task {
+            defer { isGenerating = false }
+
             do {
                 let result = try await useCase.execute(notes: input)
                 guard !Task.isCancelled else { return }
                 output = result.content
+            } catch is CancellationError {
+                // Cancellation returns to idle through the defer above.
             } catch {
                 guard !Task.isCancelled else { return }
                 errorMessage = AppAIError.userMessage(for: error)
             }
-
-            isGenerating = false
         }
     }
 

--- a/skills/foundation-models-app-builder/references/availability-and-sessions.md
+++ b/skills/foundation-models-app-builder/references/availability-and-sessions.md
@@ -115,6 +115,8 @@ final class StreamingTextViewModel {
         errorMessage = nil
 
         task = Task {
+            defer { isStreaming = false }
+
             do {
                 let session = LanguageModelSession()
                 let stream = session.streamResponse(to: Prompt(prompt))
@@ -123,12 +125,12 @@ final class StreamingTextViewModel {
                     guard !Task.isCancelled else { return }
                     output = partial.content
                 }
+            } catch is CancellationError {
+                // Cancellation returns to idle through the defer above.
             } catch {
                 guard !Task.isCancelled else { return }
                 errorMessage = FoundationModelsErrorPresenter.message(for: error)
             }
-
-            isStreaming = false
         }
     }
 

--- a/skills/foundation-models-app-builder/references/availability-and-sessions.md
+++ b/skills/foundation-models-app-builder/references/availability-and-sessions.md
@@ -1,0 +1,192 @@
+# Availability And Sessions
+
+Use this reference for model availability checks, one-shot sessions, persistent sessions, instructions, generation options, streaming snapshots, and prewarming.
+
+## Availability Gate
+
+Check availability before showing an AI-first surface. Treat unavailable models as normal product state.
+
+```swift
+import FoundationModels
+
+struct ModelAvailabilityStatus: Sendable, Hashable {
+    var isAvailable: Bool
+    var reason: String?
+}
+
+func currentFoundationModelsAvailability() -> ModelAvailabilityStatus {
+    switch SystemLanguageModel.default.availability {
+    case .available:
+        ModelAvailabilityStatus(isAvailable: true)
+    case .unavailable(let reason):
+        let message = switch reason {
+        case .deviceNotEligible:
+            "This device does not support Apple Intelligence."
+        case .appleIntelligenceNotEnabled:
+            "Apple Intelligence is not enabled."
+        case .modelNotReady:
+            "The model is still downloading or preparing."
+        @unknown default:
+            "Foundation Models are unavailable."
+        }
+
+        return ModelAvailabilityStatus(isAvailable: false, reason: message)
+    }
+}
+```
+
+## One-Shot Session
+
+Use a fresh session for unrelated commands so hidden conversation context does not leak across features.
+
+```swift
+import FoundationModels
+
+func generateTitle(for topic: String) async throws -> String {
+    let session = LanguageModelSession()
+    let response = try await session.respond(
+        to: Prompt("Generate a short, specific title for: \(topic)")
+    )
+    return response.content
+}
+```
+
+## Instructions
+
+Keep instructions short, domain-specific, and stable across prompts.
+
+```swift
+let instructions = Instructions("""
+You are a concise writing assistant.
+Prefer concrete language.
+Never invent facts that are not in the prompt.
+""")
+
+let session = LanguageModelSession(instructions: instructions)
+let response = try await session.respond(
+    to: Prompt("Rewrite this release note for developers: \(draft)")
+)
+```
+
+## Generation Options
+
+Use low temperature for extraction, classification, summaries, and app logic. Use higher temperature for brainstorming and creative writing.
+
+```swift
+let deterministic = GenerationOptions(
+    sampling: .greedy,
+    temperature: 0.1,
+    maximumResponseTokens: 160
+)
+
+let creative = GenerationOptions(
+    sampling: .random(probabilityThreshold: 0.9),
+    temperature: 0.8,
+    maximumResponseTokens: 400
+)
+
+let response = try await LanguageModelSession().respond(
+    to: Prompt("Suggest three feature names for an on-device AI app."),
+    options: creative
+)
+```
+
+## Streaming Snapshots
+
+Foundation Models streaming returns snapshots of the current response state. Assign the latest snapshot content instead of blindly appending unless your target SDK returns deltas.
+
+```swift
+import FoundationModels
+import Observation
+
+@MainActor
+@Observable
+final class StreamingTextViewModel {
+    var output = ""
+    var isStreaming = false
+    var errorMessage: String?
+
+    private var task: Task<Void, Never>?
+
+    func start(prompt: String) {
+        task?.cancel()
+        output = ""
+        isStreaming = true
+        errorMessage = nil
+
+        task = Task {
+            do {
+                let session = LanguageModelSession()
+                let stream = session.streamResponse(to: Prompt(prompt))
+
+                for try await partial in stream {
+                    guard !Task.isCancelled else { return }
+                    output = partial.content
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                errorMessage = FoundationModelsErrorPresenter.message(for: error)
+            }
+
+            isStreaming = false
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+        isStreaming = false
+    }
+}
+```
+
+## Multi-Turn Session
+
+Use a persistent session only when conversation memory is part of the feature.
+
+```swift
+let session = LanguageModelSession(
+    instructions: "Remember user preferences during this conversation."
+)
+
+let first = try await session.respond(to: Prompt("I am planning a trip to Japan."))
+let second = try await session.respond(to: Prompt("What should I pack?"))
+
+print(first.content)
+print(second.content)
+```
+
+## Prewarming
+
+Prewarm when the user is likely to submit soon and the prompt prefix is stable. Avoid prewarming every route in the app.
+
+```swift
+let session = LanguageModelSession(
+    instructions: "You generate short workout suggestions."
+)
+
+session.prewarm(promptPrefix: Prompt("Suggest a 20-minute workout for"))
+
+let response = try await session.respond(
+    to: Prompt("Suggest a 20-minute workout for someone new to exercise with no equipment.")
+)
+```
+
+## Context Budget
+
+Use the model's context size instead of hard-coding a token limit. On current SDKs, `SystemLanguageModel` also exposes token counting helpers for prompts, instructions, tools, schemas, and transcript entries.
+
+```swift
+func canFitPrompt(_ prompt: String) async -> Bool {
+    let model = SystemLanguageModel.default
+    let budget = model.contextSize
+    let promptTokens: Int
+
+    if #available(iOS 26.4, macOS 26.4, visionOS 26.4, *) {
+        promptTokens = (try? await model.tokenCount(for: Prompt(prompt))) ?? prompt.count / 4
+    } else {
+        promptTokens = prompt.count / 4
+    }
+
+    return promptTokens < Int(Double(budget) * 0.7)
+}
+```

--- a/skills/foundation-models-app-builder/references/common-errors.md
+++ b/skills/foundation-models-app-builder/references/common-errors.md
@@ -1,0 +1,96 @@
+# Common Errors
+
+Use this reference for Foundation Models errors, guardrails, retries, cancellation, and final verification.
+
+## User-Facing Error Presenter
+
+```swift
+import FoundationModels
+
+enum FoundationModelsErrorPresenter {
+    static func message(for error: Error) -> String {
+        switch error {
+        case LanguageModelSession.GenerationError.exceededContextWindowSize:
+            "The conversation is too long. Start a new chat or summarize earlier messages."
+        case LanguageModelSession.GenerationError.guardrailViolation:
+            "The request was blocked by safety guardrails."
+        case LanguageModelSession.GenerationError.assetsUnavailable:
+            "Foundation Models are temporarily unavailable."
+        case LanguageModelSession.GenerationError.concurrentRequests:
+            "Wait for the current response to finish."
+        case LanguageModelSession.GenerationError.rateLimited:
+            "Too many requests. Try again shortly."
+        case LanguageModelSession.GenerationError.unsupportedLanguageOrLocale:
+            "This language is not supported by Foundation Models."
+        case LanguageModelSession.GenerationError.decodingFailure:
+            "The response could not be decoded. Try a simpler prompt."
+        case LanguageModelSession.GenerationError.unsupportedGuide:
+            "A generation guide is unsupported."
+        case LanguageModelSession.GenerationError.refusal(_, _):
+            "The model declined to respond."
+        default:
+            error.localizedDescription
+        }
+    }
+}
+```
+
+## Retry Policy
+
+Retry only when the second attempt changes constraints.
+
+Good retry changes:
+
+- lower temperature
+- reduce maximum tokens
+- narrow instructions
+- ask for fewer fields
+- use a fresh session after context overflow
+
+Bad retry changes:
+
+- repeating the same prompt immediately
+- hiding safety or medical constraints
+- retrying write tools without user confirmation
+
+## Cancellation
+
+```swift
+@MainActor
+final class GenerationTaskStore {
+    private var task: Task<Void, Never>?
+
+    func replace(with newTask: Task<Void, Never>) {
+        task?.cancel()
+        task = newTask
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+    }
+}
+```
+
+## Verification Checklist
+
+- Model unavailable path works.
+- Permission denied path works.
+- Streaming cancellation stops UI updates.
+- Structured generation handles decoding failure.
+- Dynamic schemas pass dependencies for references.
+- Tool outputs are bounded and privacy-aware.
+- App Intents do not duplicate shared prompt logic.
+- Health wording avoids diagnosis and prescription.
+- Unsupported language path is user-facing.
+- Long prompts are checked against `SystemLanguageModel.contextSize` or `tokenCount(for:)` where available.
+
+## Build Commands
+
+Use the target app or package's equivalent commands. For example:
+
+```bash
+swift build
+swift test
+xcodebuild -project App.xcodeproj -scheme "App" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build
+```

--- a/skills/foundation-models-app-builder/references/dynamic-schemas.md
+++ b/skills/foundation-models-app-builder/references/dynamic-schemas.md
@@ -1,0 +1,140 @@
+# Dynamic Schemas
+
+Use this reference when the output schema is built at runtime: user-created forms, admin-configured extraction templates, imported schema-like definitions, invoice or receipt formats, and schema galleries.
+
+Prefer `@Generable` for app-owned compile-time models. Use `DynamicGenerationSchema` only when the shape is not known until runtime.
+
+## Object With Dependencies
+
+```swift
+import FoundationModels
+
+func makeReceiptSchema() throws -> GenerationSchema {
+    let lineItem = DynamicGenerationSchema(
+        name: "LineItem",
+        description: "One purchased item",
+        properties: [
+            DynamicGenerationSchema.Property(
+                name: "name",
+                description: "Item name",
+                schema: DynamicGenerationSchema(type: String.self)
+            ),
+            DynamicGenerationSchema.Property(
+                name: "price",
+                description: "Item price in the receipt currency",
+                schema: DynamicGenerationSchema(type: Double.self)
+            )
+        ]
+    )
+
+    let receipt = DynamicGenerationSchema(
+        name: "Receipt",
+        description: "Receipt extracted from plain text",
+        properties: [
+            DynamicGenerationSchema.Property(
+                name: "merchant",
+                schema: DynamicGenerationSchema(type: String.self)
+            ),
+            DynamicGenerationSchema.Property(
+                name: "items",
+                schema: DynamicGenerationSchema(
+                    arrayOf: DynamicGenerationSchema(referenceTo: "LineItem"),
+                    minimumElements: 1
+                )
+            ),
+            DynamicGenerationSchema.Property(
+                name: "total",
+                schema: DynamicGenerationSchema(type: Double.self)
+            )
+        ]
+    )
+
+    return try GenerationSchema(root: receipt, dependencies: [lineItem])
+}
+```
+
+## Generate Runtime Content
+
+```swift
+func extractReceipt(from text: String) async throws -> GeneratedContent {
+    let schema = try makeReceiptSchema()
+    let session = LanguageModelSession(
+        instructions: "Extract only values present in the receipt text."
+    )
+
+    return try await session.respond(
+        to: Prompt("Extract receipt data from this text:\n\(text)"),
+        schema: schema,
+        options: GenerationOptions(temperature: 0.1)
+    ).content
+}
+```
+
+## Read GeneratedContent
+
+```swift
+let output = try await extractReceipt(from: receiptText)
+let merchant: String = try output.value(forProperty: "merchant")
+let total: Double = try output.value(forProperty: "total")
+
+print("\(merchant): \(total)")
+```
+
+## Enum-Like Choices
+
+```swift
+let priority = DynamicGenerationSchema(
+    name: "Priority",
+    description: "Task priority",
+    anyOf: ["low", "medium", "high"]
+)
+```
+
+## Optional Fields
+
+```swift
+DynamicGenerationSchema.Property(
+    name: "notes",
+    description: "Optional extra notes from the source",
+    schema: DynamicGenerationSchema(type: String.self),
+    isOptional: true
+)
+```
+
+Optional means the property may be absent. Do not make fields optional just to avoid handling decoding errors.
+
+## Retry After Schema Failure
+
+```swift
+func generateDynamicContentWithRetry(
+    prompt: String,
+    schema: GenerationSchema
+) async throws -> GeneratedContent {
+    let session = LanguageModelSession()
+
+    do {
+        return try await session.respond(to: Prompt(prompt), schema: schema).content
+    } catch LanguageModelSession.GenerationError.decodingFailure {
+        let retryPrompt = """
+        \(prompt)
+
+        Return only fields allowed by the schema. Do not include unknown fields.
+        Use simple scalar values when possible.
+        """
+
+        return try await session.respond(
+            to: Prompt(retryPrompt),
+            schema: schema,
+            options: GenerationOptions(temperature: 0.0)
+        ).content
+    }
+}
+```
+
+## Checklist
+
+- Name every schema and reference consistently.
+- Pass dependencies whenever `referenceTo` is used.
+- Keep schema construction separate from SwiftUI rendering.
+- Add user-facing recovery for decoding failures.
+- Use lower temperature for extraction and classification.

--- a/skills/foundation-models-app-builder/references/healthkit.md
+++ b/skills/foundation-models-app-builder/references/healthkit.md
@@ -1,0 +1,81 @@
+# HealthKit
+
+Use this reference for HealthKit-backed Foundation Models features such as summaries, trends, coaching, nutrition analysis, and wellness check-ins.
+
+Health features must be conservative. Summarize, explain, and encourage. Do not diagnose, prescribe, or claim medical certainty.
+
+## Safe Instructions
+
+```swift
+let healthInstructions = Instructions("""
+You are a wellness assistant.
+Summarize trends and encourage healthy habits.
+Do not diagnose, prescribe, or claim medical certainty.
+Tell the user to consult a qualified professional for medical concerns.
+""")
+```
+
+## Metric Summary Model
+
+```swift
+import FoundationModels
+
+@Generable
+struct HealthSummary: Sendable {
+    let title: String
+    let overview: String
+
+    @Guide(description: "Two to four notable metric trends", .count(2...4))
+    let trends: [String]
+
+    @Guide(description: "Practical wellness suggestions, not medical advice", .count(1...3))
+    let suggestions: [String]
+
+    let safetyNote: String
+}
+```
+
+## Generate Health Summary
+
+```swift
+func generateHealthSummary(metricText: String) async throws -> HealthSummary {
+    let session = LanguageModelSession(instructions: healthInstructions)
+    let prompt = """
+    Summarize these HealthKit metrics.
+    Include the date range and avoid diagnosis.
+
+    Metrics:
+    \(metricText)
+    """
+
+    return try await session.respond(
+        to: Prompt(prompt),
+        generating: HealthSummary.self,
+        options: GenerationOptions(temperature: 0.2)
+    ).content
+}
+```
+
+## HealthKit Boundary Rules
+
+- Request HealthKit authorization before model generation.
+- Pass only the metrics needed for the feature.
+- Include date ranges and units in prompt context.
+- Handle denied authorization and empty data as normal UI states.
+- Keep model output framed as educational or motivational.
+- Do not say the model detected a disease, condition, or diagnosis.
+
+## Review Wording
+
+Prefer:
+
+- "Your step count was lower than usual this week."
+- "Consider reviewing this with a clinician if it concerns you."
+- "This summary is based on the data available on this device."
+
+Avoid:
+
+- "You have..."
+- "This indicates..."
+- "You should take..."
+- "The model diagnosed..."

--- a/skills/foundation-models-app-builder/references/multilingual.md
+++ b/skills/foundation-models-app-builder/references/multilingual.md
@@ -1,0 +1,102 @@
+# Multilingual
+
+Use this reference for supported languages, language selection, multilingual responses, and code switching.
+
+## Fresh Session Per Independent Language Task
+
+Use fresh sessions when switching languages for independent tasks.
+
+```swift
+import FoundationModels
+
+func canUseFoundationModels(for locale: Locale = .current) -> Bool {
+    SystemLanguageModel.default.supportsLocale(locale)
+}
+
+enum MultilingualGenerationError: Error, LocalizedError {
+    case unsupportedLocale
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedLocale:
+            "Foundation Models does not support this language or locale on this device."
+        }
+    }
+}
+
+func respondInLanguage(
+    prompt: String,
+    languageName: String,
+    localeIdentifier: String
+) async throws -> String {
+    let locale = Locale(identifier: localeIdentifier)
+
+    guard canUseFoundationModels(for: locale) else {
+        throw MultilingualGenerationError.unsupportedLocale
+    }
+
+    let session = LanguageModelSession(
+        instructions: Instructions("Respond in \(languageName). Keep the answer concise.")
+    )
+
+    return try await session.respond(to: Prompt(prompt)).content
+}
+```
+
+## Persistent Session For Code Switching
+
+Use one persistent session when the user expects the model to remember prior messages across languages.
+
+```swift
+let session = LanguageModelSession(
+    instructions: "Support code switching. Preserve meaning across languages."
+)
+
+let english = try await session.respond(to: Prompt("I am planning a trip to Kyoto."))
+let spanish = try await session.respond(to: Prompt("Responde ahora en español."))
+let memory = try await session.respond(to: Prompt("What city did I mention earlier?"))
+```
+
+## Language Selection Model
+
+```swift
+struct SupportedLanguageOption: Identifiable, Hashable, Sendable {
+    var id: String { localeIdentifier }
+    var localeIdentifier: String
+    var displayName: String
+    var nativeName: String
+}
+```
+
+Use `supportsLocale(_:)` for eligibility checks because it accounts for language fallbacks. Use `supportedLanguages` when you need to display the model's language list.
+
+## Unsupported Language Handling
+
+```swift
+func localizedGeneration(
+    prompt: String,
+    language: SupportedLanguageOption
+) async -> Result<String, String> {
+    do {
+        let text = try await respondInLanguage(
+            prompt: prompt,
+            languageName: language.displayName,
+            localeIdentifier: language.localeIdentifier
+        )
+        return .success(text)
+    } catch MultilingualGenerationError.unsupportedLocale,
+            LanguageModelSession.GenerationError.unsupportedLanguageOrLocale {
+        return .failure("This language is not supported by Foundation Models on this device.")
+    } catch {
+        return .failure(FoundationModelsErrorPresenter.message(for: error))
+    }
+}
+```
+
+## Prompt Rules
+
+- Name the target language explicitly in instructions.
+- Use fresh sessions for independent language outputs.
+- Use persistent sessions for deliberate code switching.
+- Localize user-facing fallback strings outside the model.
+- Do not assume every device supports every language.

--- a/skills/foundation-models-app-builder/references/rag.md
+++ b/skills/foundation-models-app-builder/references/rag.md
@@ -1,0 +1,121 @@
+# RAG
+
+Use this reference for retrieval-augmented generation over user documents, app content, notes, transcripts, web pages, or indexed local data.
+
+RAG should keep retrieval, prompt assembly, and UI state separate.
+
+## Data Types
+
+```swift
+struct RetrievedChunk: Sendable, Hashable {
+    var title: String
+    var text: String
+    var sourceURL: URL?
+}
+
+protocol DocumentRetrieving: Sendable {
+    func relevantChunks(for query: String) async throws -> [RetrievedChunk]
+}
+```
+
+## Grounded Responder
+
+```swift
+import FoundationModels
+
+struct RAGResponder {
+    var retriever: any DocumentRetrieving
+
+    func respond(to question: String) async throws -> String {
+        let chunks = try await retriever.relevantChunks(for: question)
+        let context = chunks.map { chunk in
+            """
+            Source: \(chunk.title)
+            \(chunk.text)
+            """
+        }.joined(separator: "\n\n")
+
+        let session = LanguageModelSession(
+            instructions: Instructions("""
+            Answer using only the provided context.
+            If the context is insufficient, say what is missing.
+            Cite source titles when useful.
+            """)
+        )
+
+        let prompt = """
+        Context:
+        \(context)
+
+        Question:
+        \(question)
+        """
+
+        return try await session.respond(to: Prompt(prompt)).content
+    }
+}
+```
+
+## SwiftUI Shape
+
+```swift
+@MainActor
+@Observable
+final class RAGChatViewModel {
+    var question = ""
+    var answer = ""
+    var isLoading = false
+    var errorMessage: String?
+
+    private let responder: RAGResponder
+    private var task: Task<Void, Never>?
+
+    init(responder: RAGResponder) {
+        self.responder = responder
+    }
+
+    func ask() {
+        task?.cancel()
+        let currentQuestion = question
+
+        isLoading = true
+        errorMessage = nil
+
+        task = Task {
+            do {
+                let response = try await responder.respond(to: currentQuestion)
+                guard !Task.isCancelled else { return }
+                answer = response
+            } catch {
+                guard !Task.isCancelled else { return }
+                errorMessage = FoundationModelsErrorPresenter.message(for: error)
+            }
+
+            guard !Task.isCancelled else { return }
+            isLoading = false
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+        isLoading = false
+    }
+}
+```
+
+## Prompt Rules
+
+- Keep context compact and relevant.
+- Include source titles or IDs in the prompt so the model can cite them.
+- Tell the model to say when context is insufficient.
+- Do not mix retrieved facts with hidden assumptions.
+- For private documents, avoid logging full retrieved text.
+
+## Failure States
+
+- No documents indexed.
+- No relevant chunks found.
+- Retrieval timed out.
+- The selected chunks exceed the prompt budget.
+- The model refuses or cannot answer from the provided context.

--- a/skills/foundation-models-app-builder/references/rag.md
+++ b/skills/foundation-models-app-builder/references/rag.md
@@ -82,17 +82,18 @@ final class RAGChatViewModel {
         errorMessage = nil
 
         task = Task {
+            defer { isLoading = false }
+
             do {
                 let response = try await responder.respond(to: currentQuestion)
                 guard !Task.isCancelled else { return }
                 answer = response
+            } catch is CancellationError {
+                // Cancellation returns to idle through the defer above.
             } catch {
                 guard !Task.isCancelled else { return }
                 errorMessage = FoundationModelsErrorPresenter.message(for: error)
             }
-
-            guard !Task.isCancelled else { return }
-            isLoading = false
         }
     }
 

--- a/skills/foundation-models-app-builder/references/structured-generation.md
+++ b/skills/foundation-models-app-builder/references/structured-generation.md
@@ -1,0 +1,154 @@
+# Structured Generation
+
+Use this reference for compile-time structured output with `@Generable`, `@Guide`, enums, arrays, nested objects, and decoding retries.
+
+Use `@Generable` when the app owns the output type. Use `references/dynamic-schemas.md` only when the schema must be assembled at runtime.
+
+## Basic Model
+
+```swift
+import FoundationModels
+
+@Generable
+struct BookRecommendation: Sendable {
+    @Guide(description: "The exact title of the recommended book")
+    let title: String
+
+    @Guide(description: "The author's full name")
+    let author: String
+
+    @Guide(description: "A short reason this book fits the user's request")
+    let reason: String
+
+    @Guide(description: "Difficulty from 1 for easy to 5 for demanding")
+    let difficulty: Int
+}
+
+func recommendBook(for request: String) async throws -> BookRecommendation {
+    let session = LanguageModelSession(
+        instructions: "Recommend real books only. Do not invent authors."
+    )
+
+    let response = try await session.respond(
+        to: Prompt(request),
+        generating: BookRecommendation.self
+    )
+
+    return response.content
+}
+```
+
+## Enum And Array Output
+
+```swift
+@Generable
+enum ReviewSentiment: Sendable {
+    case positive
+    case mixed
+    case negative
+}
+
+@Generable
+struct ProductReviewSummary: Sendable {
+    let productName: String
+    let sentiment: ReviewSentiment
+
+    @Guide(description: "Three concise strengths mentioned by the reviewer", .count(3))
+    let pros: [String]
+
+    @Guide(description: "One to three concrete weaknesses mentioned by the reviewer", .count(1...3))
+    let cons: [String]
+}
+
+let summary = try await LanguageModelSession().respond(
+    to: Prompt(reviewText),
+    generating: ProductReviewSummary.self
+).content
+```
+
+## Nested Output
+
+```swift
+@Generable
+struct NutritionAnalysis: Sendable {
+    let foodName: String
+    let calories: Int
+    let macros: Macros
+    let notes: [String]
+
+    @Generable
+    struct Macros: Sendable {
+        let proteinGrams: Double
+        let carbohydrateGrams: Double
+        let fatGrams: Double
+    }
+}
+```
+
+## Classification
+
+```swift
+@Generable
+struct SupportTicketClassification: Sendable {
+    let category: Category
+    let urgency: Urgency
+
+    @Guide(description: "One sentence explaining the classification")
+    let rationale: String
+
+    @Generable
+    enum Category: Sendable {
+        case billing
+        case bug
+        case featureRequest
+        case account
+        case other
+    }
+
+    @Generable
+    enum Urgency: Sendable {
+        case low
+        case medium
+        case high
+    }
+}
+```
+
+## Retry Strategy
+
+Retry only after changing constraints. For structured output, lower temperature and make the prompt stricter.
+
+```swift
+func generateStructuredWithRetry<Output: Generable & Sendable>(
+    _ type: Output.Type,
+    prompt: String,
+    instructions: String
+) async throws -> Output {
+    let session = LanguageModelSession(instructions: Instructions(instructions))
+
+    do {
+        return try await session.respond(to: Prompt(prompt), generating: type).content
+    } catch LanguageModelSession.GenerationError.decodingFailure {
+        let stricterPrompt = """
+        \(prompt)
+
+        Return only values that fit the requested Swift type.
+        Avoid unknown, null, or extra fields.
+        """
+
+        return try await session.respond(
+            to: Prompt(stricterPrompt),
+            generating: type,
+            options: GenerationOptions(temperature: 0.0)
+        ).content
+    }
+}
+```
+
+## Checklist
+
+- Prefer concrete property names over generic fields like `value`.
+- Add guides for meaning, count, ranges, allowed style, or ambiguity.
+- Keep generated types `Sendable` when crossing concurrency boundaries.
+- Use lower temperature for extraction and classification.
+- Handle `decodingFailure` with user-facing recovery.

--- a/skills/foundation-models-app-builder/references/tool-calling.md
+++ b/skills/foundation-models-app-builder/references/tool-calling.md
@@ -1,0 +1,152 @@
+# Tool Calling
+
+Use this reference when Foundation Models needs app capabilities such as weather, search, contacts, calendar, reminders, location, HealthKit, music, or web metadata.
+
+Tool calling is app integration work. Model the intent, permissions, validation, failure cases, and user confirmation.
+
+## Basic Tool
+
+```swift
+import Foundation
+import FoundationModels
+
+struct CalculatorTool: Tool {
+    let name = "calculate"
+    let description = "Perform basic arithmetic."
+
+    @Generable
+    struct Arguments: Sendable {
+        let firstNumber: Double
+        let operation: Operation
+        let secondNumber: Double
+    }
+
+    @Generable
+    enum Operation: Sendable {
+        case add
+        case subtract
+        case multiply
+        case divide
+    }
+
+    @Generable
+    struct CalculationResult: Sendable {
+        let expression: String
+        let result: Double
+    }
+
+    enum CalculationError: Error, LocalizedError {
+        case divisionByZero
+
+        var errorDescription: String? {
+            switch self {
+            case .divisionByZero:
+                "Cannot divide by zero."
+            }
+        }
+    }
+
+    func call(arguments: Arguments) async throws -> CalculationResult {
+        let result = switch arguments.operation {
+        case .add:
+            arguments.firstNumber + arguments.secondNumber
+        case .subtract:
+            arguments.firstNumber - arguments.secondNumber
+        case .multiply:
+            arguments.firstNumber * arguments.secondNumber
+        case .divide:
+            guard arguments.secondNumber != 0 else {
+                throw CalculationError.divisionByZero
+            }
+            arguments.firstNumber / arguments.secondNumber
+        }
+
+        return CalculationResult(
+            expression: "\(arguments.firstNumber) \(arguments.operation.symbol) \(arguments.secondNumber)",
+            result: result
+        )
+    }
+}
+
+private extension CalculatorTool.Operation {
+    var symbol: String {
+        switch self {
+        case .add: "+"
+        case .subtract: "-"
+        case .multiply: "*"
+        case .divide: "/"
+        }
+    }
+}
+```
+
+## Session With Tool
+
+```swift
+let session = LanguageModelSession(
+    tools: [CalculatorTool()],
+    instructions: "Use the calculator tool for arithmetic. Explain the result briefly."
+)
+
+let response = try await session.respond(
+    to: Prompt("What is 19.5 multiplied by 4.2?")
+)
+```
+
+## Recoverable Tool Output
+
+Prefer structured failure output when the model can recover. Throw when the app should stop execution.
+
+```swift
+@Generable
+struct ToolResult: Sendable {
+    let success: Bool
+    let message: String
+    let value: String?
+}
+```
+
+## Write Tool Confirmation
+
+For tools that write data, split planning from committing.
+
+```swift
+@Generable
+struct ReminderDraft: Sendable {
+    let title: String
+    let dueDateDescription: String?
+    let priority: Priority
+
+    @Generable
+    enum Priority: Sendable {
+        case low
+        case medium
+        case high
+    }
+}
+```
+
+Flow:
+
+1. Let the model create a draft.
+2. Show the draft to the user.
+3. Commit to Reminders, Calendar, Contacts, or files only after explicit confirmation.
+
+## Permission Boundaries
+
+- Contacts: search narrowly; do not pass full address books to the model.
+- Calendar: preview event creation before saving.
+- Reminders: preview title, due date, priority, and notes.
+- Location: request foreground location only when needed.
+- Music: handle no subscription or denied media access.
+- HealthKit: expose selected metrics and date ranges clearly.
+
+## Tool Design Checklist
+
+- The `name` is short and action-oriented.
+- The `description` tells the model when to use the tool.
+- Arguments are strongly typed and constrained with `@Generable`.
+- The tool validates input before touching app data.
+- Tool implementations are safe if called concurrently.
+- The output is bounded and does not leak unnecessary private data.
+- Permission denial is a normal result path.

--- a/skills/foundation-models-app-builder/references/voice.md
+++ b/skills/foundation-models-app-builder/references/voice.md
@@ -1,0 +1,88 @@
+# Voice
+
+Use this reference for speech recognition, voice commands, text-to-speech responses, and voice-first Foundation Models flows.
+
+Keep speech recognition, model inference, and speech synthesis as separate services. A voice feature should always support cancellation and visible state.
+
+## State Machine
+
+```swift
+enum VoiceInteractionState: Equatable {
+    case idle
+    case requestingPermission
+    case listening
+    case transcribing
+    case generating
+    case speaking
+    case failed(String)
+}
+```
+
+## View Model Shape
+
+```swift
+import FoundationModels
+import Observation
+
+@MainActor
+@Observable
+final class VoiceAssistantViewModel {
+    var state: VoiceInteractionState = .idle
+    var transcript = ""
+    var response = ""
+
+    private var task: Task<Void, Never>?
+
+    func handleFinalTranscript(_ text: String) {
+        task?.cancel()
+        transcript = text
+        state = .generating
+
+        task = Task {
+            do {
+                let session = LanguageModelSession(
+                    instructions: "Respond conversationally for spoken output. Keep it concise."
+                )
+                response = try await session.respond(to: Prompt(text)).content
+                state = .speaking
+                // Send `response` to an AVSpeechSynthesizer wrapper here.
+            } catch {
+                state = .failed(FoundationModelsErrorPresenter.message(for: error))
+            }
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+        state = .idle
+    }
+}
+```
+
+## Voice Command Tool
+
+Use tool calling when voice should perform app actions.
+
+```swift
+let session = LanguageModelSession(
+    tools: [CreateReminderDraftTool()],
+    instructions: Instructions("""
+    Convert spoken requests into reminder drafts.
+    Do not save anything until the user confirms.
+    """)
+)
+```
+
+## Permissions
+
+Request microphone and speech recognition permission before entering the listening state. Permission denial should return to `.idle` or `.failed` with a clear recovery message.
+
+## UX Checklist
+
+- Show when the app is listening, thinking, and speaking.
+- Provide a visible cancel button.
+- Keep spoken responses shorter than text responses.
+- Confirm before write actions.
+- Handle interruptions such as phone calls, route changes, and app backgrounding.
+- Avoid reading sensitive data aloud without explicit user action.

--- a/skills/foundation-models-app-builder/references/voice.md
+++ b/skills/foundation-models-app-builder/references/voice.md
@@ -46,6 +46,8 @@ final class VoiceAssistantViewModel {
                 response = try await session.respond(to: Prompt(text)).content
                 state = .speaking
                 // Send `response` to an AVSpeechSynthesizer wrapper here.
+            } catch is CancellationError {
+                state = .idle
             } catch {
                 state = .failed(FoundationModelsErrorPresenter.message(for: error))
             }

--- a/skills/foundation-models-os27-updater/SKILL.md
+++ b/skills/foundation-models-os27-updater/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: foundation-models-os27-updater
+description: Upgrade any Apple Foundation Models Swift app or package from OS 26-era APIs to OS 27 and Xcode 27 APIs. Use when modernizing LanguageModelSession code, GenerationOptions, tool calling, context-window handling, image input, Private Cloud Compute, shared LanguageModel runtimes, reasoning controls, transcript handling, custom executors, feedback, availability gates, docs, examples, tests, or build settings.
+---
+
+# Foundation Models OS 27 Updater
+
+Use this skill to migrate a Foundation Models project from the OS 26 API surface to OS 27. The target may be an app, Swift package, sample, CLI, framework, tutorial repo, or documentation repo. Do not assume any specific app or package repository structure.
+
+The goal is not to sprinkle OS 27 names into code. The goal is to make the project take real advantage of OS 27 where it helps: better runtime selection, context management, tool policy, multimodal input, transcript handling, observability, and honest availability behavior.
+
+## Operating Principles
+
+- Start from the target project, not from a generic example.
+- Inspect the installed Xcode 27 SDK before claiming an API exists.
+- Preserve unrelated user changes.
+- Prefer small typed adapters over one giant compatibility layer.
+- Keep OS 27 features discoverable without forcing demos that do not fit the product.
+- Make availability, entitlement, service eligibility, quota, and platform gates visible in code and docs.
+- Compile with Xcode 27 even if runtime smoke tests require OS 27 hardware.
+
+## First Pass: Understand The Project
+
+Run a fast audit before editing:
+
+```bash
+git status --short --branch
+rg -n "import FoundationModels|LanguageModelSession|SystemLanguageModel|GenerationOptions|Prompt|Transcript|Tool|@Generable|DynamicGenerationSchema|GeneratedContent|Feedback|Attachment|ImageReference|tokenCount|contextSize" .
+rg -n "IPHONEOS_DEPLOYMENT_TARGET|MACOSX_DEPLOYMENT_TARGET|VISIONOS_DEPLOYMENT_TARGET|WATCHOS_DEPLOYMENT_TARGET|platforms:|Package.swift|swift-tools-version" .
+find . -maxdepth 3 \( -name "*.xcodeproj" -o -name "*.xcworkspace" -o -name "Package.swift" \)
+```
+
+Then classify the work:
+
+- **App**: update user-facing flows, availability UI, build settings, and simulator/device verification.
+- **Swift package/framework**: expose OS 27 APIs through reusable types; avoid app-specific UI assumptions.
+- **Sample/tutorial**: add focused examples and comments that teach migration choices.
+- **CLI/tooling**: expose flags for runtime, context, tool mode, reasoning, and diagnostics where useful.
+- **Docs-only repo**: update examples, platform requirements, deprecation notes, and verification snippets.
+
+## SDK Inspection
+
+Use the active Xcode 27 SDK as the source of truth. Adapt paths for the user's Xcode:
+
+```bash
+export DEVELOPER_DIR=/Users/rudrank/Downloads/Xcode-beta.app/Contents/Developer
+xcrun --show-sdk-path --sdk iphoneos
+xcrun --show-sdk-path --sdk macosx
+```
+
+Search FoundationModels interfaces:
+
+```bash
+SDK="$(xcrun --show-sdk-path --sdk iphoneos)"
+rg -n "final public class PrivateCloudComputeLanguageModel|protocol LanguageModel|contextSize|toolCallingMode|samplingMode|ImageAttachment|ImageReference|reasoning|Transcript|Feedback|LanguageModelExecutor" "$SDK/System/Library/Frameworks/FoundationModels.framework"
+```
+
+If the project has its own generated interface notes, refresh or verify them from SDK interfaces. Do not let stale docs outrank the local SDK.
+
+## Migration Decision
+
+Choose one path explicitly:
+
+- **OS 27-only**: raise deployment targets and package platforms, simplify code to OS 27 APIs, and remove noisy OS 26 compatibility only where the user wants that.
+- **OS 26 + OS 27 compatible**: keep the existing OS 26 path and isolate new symbols behind `#available` wrappers or separate OS 27-only files.
+- **Compile-only OS 27 support**: update source to build with Xcode 27 while noting runtime features that cannot be exercised on the current host.
+
+For packages, prefer public wrappers that compile for the declared platform matrix. Avoid leaking OS 27-only symbols into APIs that must be consumed from OS 26 without availability annotations.
+
+## API Migration Checklist
+
+### GenerationOptions
+
+Update renamed or expanded options first because they break builds quickly:
+
+- Replace deprecated sampling spelling with `samplingMode` when the SDK exposes it.
+- Add `toolCallingMode` only where behavior should change.
+- Keep temperature, max tokens, and sampling controls near existing generation configuration.
+- Ensure docs and CLI flags use the same names as the code.
+
+### Model Availability
+
+Keep availability checks close to features:
+
+```swift
+let model = SystemLanguageModel.default
+switch model.availability {
+case .available:
+    break
+case .unavailable(let reason):
+    // Render or return a clear unavailable state.
+}
+```
+
+For OS 27 additions, combine Foundation Models availability with platform checks:
+
+```swift
+if #available(iOS 27.0, macOS 27.0, visionOS 27.0, *) {
+    let contextSize = SystemLanguageModel.default.contextSize
+} else {
+    // Existing OS 26 fallback.
+}
+```
+
+### Shared LanguageModel Runtime
+
+If the project has multiple model backends or wants PCC, introduce a small runtime abstraction:
+
+- `.system` for `SystemLanguageModel.default`.
+- `.privateCloudCompute` for `PrivateCloudComputeLanguageModel()`.
+- `.automatic` or `.pccWhenAvailable` only if the app has a clear fallback policy.
+
+Avoid re-resolving adaptive runtime mid-request. Resolve once, create the session from that model, and use the same resolved runtime for diagnostics and token/context accounting.
+
+### Private Cloud Compute
+
+Add PCC only when it serves the product or sample. PCC code should report:
+
+- availability
+- unavailable reason
+- quota status and reset date when available
+- context size, which may be async and throwing
+- supported languages if exposed by the SDK
+- network, service, quota, and eligibility failures
+
+Do not present PCC as guaranteed. Treat it as OS/service/entitlement/network gated.
+
+### Context Window And Token Budget
+
+Replace hardcoded context assumptions with runtime information:
+
+- `SystemLanguageModel.contextSize` for local model budget when available.
+- PCC context size through the PCC API when available.
+- `tokenCount(for:)` or existing project token accounting for prompt pressure.
+- Summarization, truncation, or refusal when a prompt exceeds budget.
+
+Good app behavior:
+
+- show or log budget in diagnostics
+- compact long conversation history before overflow
+- catch context-size-exceeded errors and provide a recovery path
+
+### Tool Calling Mode
+
+Map product modes to explicit tool policy:
+
+- `.allowed`: normal assistant mode where tools are optional.
+- `.required`: workflows that must call a tool to be useful, such as fetching current data.
+- `.disallowed`: drafting, summarization, or privacy-sensitive flows where tools should not run.
+
+Do not rely on prompts alone to prevent tool use when the SDK exposes a policy option.
+
+### Image Input
+
+When adding image support:
+
+- prefer typed prompt/attachment APIs over stringly image descriptions
+- keep text-only fallbacks
+- gate UIKit/AppKit convenience initializers by platform
+- handle missing image permission or unsupported image content cleanly
+- update examples to show the actual image path or picker behavior
+
+### Dynamic Instructions And Profiles
+
+If the app has user-selectable personas or modes, move them into typed configuration:
+
+- model/runtime
+- instructions
+- generation options
+- tool policy
+- reasoning level
+- language/locale
+- safety or privacy mode
+
+Keep reset/default behavior obvious so users can return to a known profile.
+
+### Reasoning Controls
+
+Expose reasoning controls only when users can understand the tradeoff:
+
+- use small labels like light, balanced, deep, or project-specific names
+- explain cost/latency/quality implications in docs or settings text
+- avoid claiming better answers without measuring or demonstrating it
+
+### Transcript Handling
+
+Update transcript parsing, rendering, replay, export, and logging for new segment types:
+
+- text segments
+- tool calls and tool results
+- reasoning segments
+- attachments
+- custom or unknown segments
+- feedback-related entries if present
+
+Make switches exhaustive. If preserving transcripts matters, store unknown/custom segments instead of dropping them.
+
+### Custom Executors
+
+If the project implements a custom model executor:
+
+- update method signatures to the Xcode 27 shape
+- keep streaming channel behavior cancellable
+- test the executor with a fake response path
+- document whether the executor supports tools, images, reasoning, and structured output
+
+### Feedback And Observability
+
+Use OS 27 feedback/transcript surfaces to improve debugging:
+
+- attach feedback to the relevant transcript/session when supported
+- record runtime, availability, context size, token count, tool mode, and error category
+- avoid logging private prompt or Health/Contacts/Calendar data unless the app already has consented diagnostics
+
+## Code Organization Patterns
+
+For apps:
+
+```text
+Models/
+  FoundationModelRuntime.swift
+  FoundationModelAvailabilityState.swift
+Services/
+  FoundationModelClient.swift
+  ContextBudgetManager.swift
+Views/
+  ModelUnavailableView.swift
+  RuntimeDiagnosticsView.swift
+```
+
+For packages:
+
+```text
+Sources/PackageName/
+  Runtime/
+  Context/
+  Tools/
+  Transcripts/
+Tests/PackageNameTests/
+```
+
+Keep SwiftUI views thin. Put Foundation Models orchestration in services/use cases so CLI, widgets, App Intents, and tests can reuse it.
+
+## Documentation Updates
+
+Update docs when code behavior changes:
+
+- minimum Xcode version
+- deployment targets and platform matrix
+- Apple Intelligence requirements
+- PCC entitlement or service eligibility requirements
+- OS 26 fallback behavior, if preserved
+- OS 27-only examples
+- build command using `DEVELOPER_DIR`
+- runtime testing limitations on non-OS 27 hosts
+
+Avoid vague phrasing like "uses latest APIs" without naming what changed.
+
+## Verification Matrix
+
+Choose the narrowest checks that cover the change:
+
+```bash
+git diff --check
+DEVELOPER_DIR=/path/to/Xcode-beta.app/Contents/Developer swift build
+DEVELOPER_DIR=/path/to/Xcode-beta.app/Contents/Developer swift test
+DEVELOPER_DIR=/path/to/Xcode-beta.app/Contents/Developer xcodebuild -project App.xcodeproj -scheme "App" -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath ./build-xcode27 build
+```
+
+Also verify manually when possible:
+
+- model availability renders correctly when unavailable
+- system runtime can generate a simple response
+- PCC unavailable state is graceful
+- context budget displays or logs correctly
+- tool mode changes behavior
+- image prompt path works or falls back cleanly
+- transcript export/replay does not crash on new segments
+
+If runtime smoke tests require OS 27 hardware or entitlement approval, say that plainly in the final report and PR body.
+
+## PR Expectations
+
+A good migration PR should include:
+
+- short summary of which OS 27 surfaces were adopted
+- whether OS 26 compatibility was kept or dropped
+- files touched by category: build settings, runtime code, UI/examples, docs/tests
+- validation commands and results
+- runtime limitations that could not be tested locally
+- follow-up work only when it is truly outside the current safe scope
+
+Do not claim a feature is live just because it compiles. For OS/service-gated APIs like PCC, distinguish compile support, availability probing, entitlement status, and real runtime success.

--- a/skills/foundation-models-os27-updater/SKILL.md
+++ b/skills/foundation-models-os27-updater/SKILL.md
@@ -43,7 +43,7 @@ Then classify the work:
 Use the active Xcode 27 SDK as the source of truth. Adapt paths for the user's Xcode:
 
 ```bash
-export DEVELOPER_DIR=/Users/rudrank/Downloads/Xcode-beta.app/Contents/Developer
+export DEVELOPER_DIR=/path/to/Xcode-beta.app/Contents/Developer
 xcrun --show-sdk-path --sdk iphoneos
 xcrun --show-sdk-path --sdk macosx
 ```

--- a/skills/foundation-models-os27-updater/agents/openai.yaml
+++ b/skills/foundation-models-os27-updater/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Foundation Models OS 27 Updater"
+  short_description: "Upgrade any Foundation Models project from OS 26 APIs to OS 27."
+  default_prompt: "Upgrade this Foundation Models project from OS 26-era APIs to OS 27, using the Xcode 27 SDK and verifying the build."


### PR DESCRIPTION
## Summary
- add the reusable Foundation Models app-builder skill to the canonical Kit repo
- add the Foundation Models OS 27 updater skill to the canonical Kit repo
- make the app-builder validation example repo-neutral instead of Foundation Lab-specific

## Validation
- `PYTHONPATH=/tmp/codex-pyyaml python3 /Users/rudrank/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/foundation-models-app-builder`
- `PYTHONPATH=/tmp/codex-pyyaml python3 /Users/rudrank/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/foundation-models-os27-updater`
