### PR TITLE
Move AFM runtime APIs into FoundationModelsKit

### DIFF
--- a/Sources/FoundationModelsKit/Capabilities/FoundationModelAvailabilityUseCase.swift
+++ b/Sources/FoundationModelsKit/Capabilities/FoundationModelAvailabilityUseCase.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct FoundationModelAvailabilityUseCase: Sendable {
+    public static let descriptor = FoundationModelCapabilityDescriptor(
+        id: "foundation-models.check-availability",
+        displayName: "Check Model Availability",
+        summary: "Checks whether Apple Intelligence is currently available."
+    )
+
+    private let checker: any FoundationModelAvailabilityChecking
+
+    public init(checker: any FoundationModelAvailabilityChecking = FoundationModelsModelAvailabilityChecker()) {
+        self.checker = checker
+    }
+
+    public func execute(
+        useCase: FoundationModelUseCase = .general
+    ) -> FoundationModelAvailability {
+        checker.currentAvailability(useCase: useCase)
+    }
+}

--- a/Sources/FoundationModelsKit/Capabilities/FoundationModelCapability.swift
+++ b/Sources/FoundationModelsKit/Capabilities/FoundationModelCapability.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public protocol FoundationModelCapabilityRequest: Sendable {}
+
+public protocol FoundationModelCapabilityResult: Sendable {}
+
+public struct FoundationModelCapabilityDescriptor: Sendable, Hashable {
+    public let id: String
+    public let displayName: String
+    public let summary: String
+
+    public init(id: String, displayName: String, summary: String) {
+        self.id = id
+        self.displayName = displayName
+        self.summary = summary
+    }
+}
+
+/// A task-oriented use case that can be shared by the app, App Intents, and CLI adapters.
+public protocol FoundationModelCapabilityUseCase: Sendable {
+    associatedtype Request: FoundationModelCapabilityRequest
+    associatedtype Result: FoundationModelCapabilityResult
+
+    static var descriptor: FoundationModelCapabilityDescriptor { get }
+
+    func execute(_ request: Request) async throws -> Result
+}

--- a/Sources/FoundationModelsKit/Capabilities/FoundationModelDynamicSchemaGenerationUseCase.swift
+++ b/Sources/FoundationModelsKit/Capabilities/FoundationModelDynamicSchemaGenerationUseCase.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct FoundationModelDynamicSchemaGenerationUseCase: FoundationModelCapabilityUseCase {
+    public static let descriptor = FoundationModelCapabilityDescriptor(
+        id: "foundation-models.generate-dynamic-schema",
+        displayName: "Generate Dynamic Schema Content",
+        summary: "Generates content using a runtime-defined generation schema."
+    )
+
+    private let provider: any FoundationModelDynamicSchemaGenerating
+
+    public init(provider: any FoundationModelDynamicSchemaGenerating = FoundationModelsDynamicSchemaGenerator()) {
+        self.provider = provider
+    }
+
+    public func execute(
+        _ request: FoundationModelDynamicSchemaGenerationRequest
+    ) async throws -> FoundationModelDynamicSchemaGenerationResult {
+        guard !request.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw FoundationModelsKitError.invalidRequest("Missing prompt")
+        }
+
+        return try await provider.generate(for: request)
+    }
+}

--- a/Sources/FoundationModelsKit/Capabilities/FoundationModelQuotaUsageInspectionUseCase.swift
+++ b/Sources/FoundationModelsKit/Capabilities/FoundationModelQuotaUsageInspectionUseCase.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct FoundationModelQuotaUsageInspectionUseCase: Sendable {
+    public static let descriptor = FoundationModelCapabilityDescriptor(
+        id: "foundation-models.inspect-quota-usage",
+        displayName: "Inspect Model Quota Usage",
+        summary: "Reports Private Cloud Compute quota state without inventing numeric usage."
+    )
+
+    private let inspector: any FoundationModelRuntimeInspecting
+
+    public init(inspector: any FoundationModelRuntimeInspecting = FoundationModelsRuntimeInspector()) {
+        self.inspector = inspector
+    }
+
+    public func execute(
+        runtimes: [FoundationModelRuntime] = FoundationModelRuntime.allCases
+    ) -> [FoundationModelQuotaUsage] {
+        runtimes.map(inspector.quotaUsage(for:))
+    }
+}

--- a/Sources/FoundationModelsKit/Capabilities/FoundationModelRuntimeInspectionUseCase.swift
+++ b/Sources/FoundationModelsKit/Capabilities/FoundationModelRuntimeInspectionUseCase.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public struct FoundationModelRuntimeInspectionUseCase: Sendable {
+    public static let descriptor = FoundationModelCapabilityDescriptor(
+        id: "foundation-models.inspect-runtime",
+        displayName: "Inspect Model Runtime",
+        summary: "Reports availability for on-device and Private Cloud Compute models."
+    )
+
+    private let inspector: any FoundationModelRuntimeInspecting
+
+    public init(inspector: any FoundationModelRuntimeInspecting = FoundationModelsRuntimeInspector()) {
+        self.inspector = inspector
+    }
+
+    public func execute(
+        runtimes: [FoundationModelRuntime] = FoundationModelRuntime.allCases
+    ) -> [FoundationModelRuntimeStatus] {
+        runtimes.map(inspector.status(for:))
+    }
+}

--- a/Sources/FoundationModelsKit/Capabilities/FoundationModelStreamingTextGenerationUseCase.swift
+++ b/Sources/FoundationModelsKit/Capabilities/FoundationModelStreamingTextGenerationUseCase.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct FoundationModelStreamingTextGenerationUseCase: Sendable {
+    public static let descriptor = FoundationModelCapabilityDescriptor(
+        id: "foundation-models.stream-text",
+        displayName: "Stream Text",
+        summary: "Streams text generation updates using Foundation Models."
+    )
+
+    private let provider: any StreamingFoundationModelTextGenerating
+
+    public init(provider: any StreamingFoundationModelTextGenerating = FoundationModelsStreamingTextGenerator()) {
+        self.provider = provider
+    }
+
+    public func execute(
+        _ request: FoundationModelStreamingTextGenerationRequest,
+        onPartialResponse: @escaping @Sendable (String) async -> Void
+    ) async throws -> FoundationModelTextGenerationResult {
+        guard !request.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw FoundationModelsKitError.invalidRequest("Missing prompt")
+        }
+
+        return try await provider.streamText(
+            for: request,
+            onPartialResponse: onPartialResponse
+        )
+    }
+}

--- a/Sources/FoundationModelsKit/Capabilities/FoundationModelStructuredGenerationUseCase.swift
+++ b/Sources/FoundationModelsKit/Capabilities/FoundationModelStructuredGenerationUseCase.swift
@@ -1,0 +1,28 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelStructuredGenerationUseCase<Output: Generable & Sendable>: FoundationModelCapabilityUseCase {
+    public static var descriptor: FoundationModelCapabilityDescriptor {
+        FoundationModelCapabilityDescriptor(
+            id: "foundation-models.generate-structured-data",
+            displayName: "Generate Structured Data",
+            summary: "Generates type-safe structured data using Foundation Models."
+        )
+    }
+
+    private let provider: any FoundationModelStructuredGenerating
+
+    public init(provider: any FoundationModelStructuredGenerating = FoundationModelsStructuredGenerator()) {
+        self.provider = provider
+    }
+
+    public func execute(
+        _ request: FoundationModelStructuredGenerationRequest<Output>
+    ) async throws -> FoundationModelStructuredGenerationResult<Output> {
+        guard !request.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw FoundationModelsKitError.invalidRequest("Missing prompt")
+        }
+
+        return try await provider.generate(Output.self, for: request)
+    }
+}

--- a/Sources/FoundationModelsKit/Capabilities/FoundationModelSupportedLanguagesUseCase.swift
+++ b/Sources/FoundationModelsKit/Capabilities/FoundationModelSupportedLanguagesUseCase.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public struct FoundationModelSupportedLanguagesUseCase: Sendable {
+    public static let descriptor = FoundationModelCapabilityDescriptor(
+        id: "foundation-models.list-supported-languages",
+        displayName: "List Supported Languages",
+        summary: "Lists the languages supported by the current Foundation Models runtime."
+    )
+
+    private let lister: any FoundationModelSupportedLanguageListing
+
+    public init(lister: any FoundationModelSupportedLanguageListing = FoundationModelsSupportedLanguageLister()) {
+        self.lister = lister
+    }
+
+    public func execute(
+        useCase: FoundationModelUseCase = .general,
+        locale: Locale = .current
+    ) -> FoundationModelSupportedLanguages {
+        lister.supportedLanguages(useCase: useCase, locale: locale)
+    }
+}

--- a/Sources/FoundationModelsKit/Capabilities/FoundationModelTextGenerationUseCase.swift
+++ b/Sources/FoundationModelsKit/Capabilities/FoundationModelTextGenerationUseCase.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public struct FoundationModelTextGenerationUseCase: FoundationModelCapabilityUseCase {
+    public static let descriptor = FoundationModelCapabilityDescriptor(
+        id: "foundation-models.generate-text",
+        displayName: "Generate Text",
+        summary: "Generates text from a prompt using Foundation Models."
+    )
+
+    private let provider: any FoundationModelTextGenerating
+
+    public init(provider: any FoundationModelTextGenerating = FoundationModelsTextGenerator()) {
+        self.provider = provider
+    }
+
+    public func execute(_ request: FoundationModelTextGenerationRequest) async throws -> FoundationModelTextGenerationResult {
+        guard !request.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw FoundationModelsKitError.invalidRequest("Missing prompt")
+        }
+
+        return try await provider.generateText(for: request)
+    }
+}

--- a/Sources/FoundationModelsKit/Errors/FoundationModelErrorProjection.swift
+++ b/Sources/FoundationModelsKit/Errors/FoundationModelErrorProjection.swift
@@ -1,0 +1,237 @@
+import Foundation
+import FoundationModels
+
+/// A stable, machine-readable view of Foundation Models failures across framework generations.
+public struct FoundationModelErrorProjection: Sendable, Hashable, Codable {
+    public enum Category: String, Sendable, Hashable, Codable {
+        case contextSizeExceeded = "context_size_exceeded"
+        case assetsUnavailable = "assets_unavailable"
+        case guardrailViolation = "guardrail_violation"
+        case refusal
+        case unsupportedCapability = "unsupported_capability"
+        case unsupportedTranscriptContent = "unsupported_transcript_content"
+        case unsupportedGenerationGuide = "unsupported_generation_guide"
+        case unsupportedLanguageOrLocale = "unsupported_language_or_locale"
+        case decodingFailure = "decoding_failure"
+        case rateLimited = "rate_limited"
+        case concurrentRequests = "concurrent_requests"
+        case transcriptMutationWhileResponding = "transcript_mutation_while_responding"
+        case timeout
+        case networkFailure = "network_failure"
+        case quotaLimitReached = "quota_limit_reached"
+        case serviceUnavailable = "service_unavailable"
+        case unknown
+    }
+
+    public enum Capability: String, Sendable, Hashable, Codable {
+        case vision
+        case guidedGeneration = "guided_generation"
+        case reasoning
+        case toolCalling = "tool_calling"
+        case unknown
+    }
+
+    public let category: Category
+    public let contextSize: Int?
+    public let attemptedTokenCount: Int?
+    public let resetDate: Date?
+    public let capability: Capability?
+    public let schemaName: String?
+    public let languageCode: String?
+    public let unsupportedTranscriptEntryCount: Int?
+    public let hasQuotaLimitIncreaseSuggestion: Bool?
+
+    public var isContextOverflow: Bool {
+        category == .contextSizeExceeded
+    }
+
+    public static func isContextOverflow(_ error: any Error) -> Bool {
+        project(error)?.isContextOverflow == true
+    }
+
+    public static func project(_ error: any Error) -> Self? {
+        if let generationError = error as? LanguageModelSession.GenerationError {
+            return project(generationError)
+        }
+
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            if let modelError = error as? FoundationModels.LanguageModelError {
+                return project(modelError)
+            }
+            if let systemModelError = error as? SystemLanguageModel.Error {
+                return project(systemModelError)
+            }
+            if let sessionError = error as? LanguageModelSession.Error {
+                return project(sessionError)
+            }
+            if let privateCloudError = error as? PrivateCloudComputeLanguageModel.Error {
+                return project(privateCloudError)
+            }
+            if let parsingError = error as? GeneratedContent.ParsingError {
+                return project(parsingError)
+            }
+        }
+        #endif
+
+        return nil
+    }
+
+    private init(
+        category: Category,
+        contextSize: Int? = nil,
+        attemptedTokenCount: Int? = nil,
+        resetDate: Date? = nil,
+        capability: Capability? = nil,
+        schemaName: String? = nil,
+        languageCode: String? = nil,
+        unsupportedTranscriptEntryCount: Int? = nil,
+        hasQuotaLimitIncreaseSuggestion: Bool? = nil
+    ) {
+        self.category = category
+        self.contextSize = contextSize
+        self.attemptedTokenCount = attemptedTokenCount
+        self.resetDate = resetDate
+        self.capability = capability
+        self.schemaName = schemaName
+        self.languageCode = languageCode
+        self.unsupportedTranscriptEntryCount = unsupportedTranscriptEntryCount
+        self.hasQuotaLimitIncreaseSuggestion = hasQuotaLimitIncreaseSuggestion
+    }
+}
+
+private extension FoundationModelErrorProjection {
+    static func project(_ error: LanguageModelSession.GenerationError) -> Self {
+        switch error {
+        case .exceededContextWindowSize:
+            Self(category: .contextSizeExceeded)
+        case .assetsUnavailable:
+            Self(category: .assetsUnavailable)
+        case .guardrailViolation:
+            Self(category: .guardrailViolation)
+        case .unsupportedGuide:
+            Self(category: .unsupportedGenerationGuide)
+        case .unsupportedLanguageOrLocale:
+            Self(category: .unsupportedLanguageOrLocale)
+        case .decodingFailure:
+            Self(category: .decodingFailure)
+        case .rateLimited:
+            Self(category: .rateLimited)
+        case .concurrentRequests:
+            Self(category: .concurrentRequests)
+        case .refusal:
+            Self(category: .refusal)
+        @unknown default:
+            Self(category: .unknown)
+        }
+    }
+
+    #if compiler(>=6.4)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_ error: FoundationModels.LanguageModelError) -> Self {
+        switch error {
+        case .contextSizeExceeded(let context):
+            Self(
+                category: .contextSizeExceeded,
+                contextSize: context.contextSize,
+                attemptedTokenCount: context.tokenCount
+            )
+        case .rateLimited(let context):
+            Self(
+                category: .rateLimited,
+                resetDate: context.resetDate
+            )
+        case .guardrailViolation:
+            Self(category: .guardrailViolation)
+        case .refusal:
+            Self(category: .refusal)
+        case .unsupportedCapability(let context):
+            Self(
+                category: .unsupportedCapability,
+                capability: project(context.capability)
+            )
+        case .unsupportedTranscriptContent(let context):
+            Self(
+                category: .unsupportedTranscriptContent,
+                unsupportedTranscriptEntryCount: context.unsupportedContent.count
+            )
+        case .unsupportedGenerationGuide(let context):
+            Self(
+                category: .unsupportedGenerationGuide,
+                schemaName: context.schemaName
+            )
+        case .unsupportedLanguageOrLocale(let context):
+            Self(
+                category: .unsupportedLanguageOrLocale,
+                languageCode: context.languageCode.identifier
+            )
+        case .timeout:
+            Self(category: .timeout)
+        @unknown default:
+            Self(category: .unknown)
+        }
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_ error: SystemLanguageModel.Error) -> Self {
+        switch error {
+        case .assetsUnavailable:
+            Self(category: .assetsUnavailable)
+        @unknown default:
+            Self(category: .unknown)
+        }
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_ error: LanguageModelSession.Error) -> Self {
+        switch error {
+        case .concurrentRequests:
+            Self(category: .concurrentRequests)
+        case .transcriptMutationWhileResponding:
+            Self(category: .transcriptMutationWhileResponding)
+        @unknown default:
+            Self(category: .unknown)
+        }
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_ error: PrivateCloudComputeLanguageModel.Error) -> Self {
+        switch error {
+        case .networkFailure:
+            Self(category: .networkFailure)
+        case .quotaLimitReached(let context):
+            Self(
+                category: .quotaLimitReached,
+                resetDate: context.resetDate,
+                hasQuotaLimitIncreaseSuggestion: context.limitIncreaseSuggestion != nil
+            )
+        case .serviceUnavailable:
+            Self(category: .serviceUnavailable)
+        @unknown default:
+            Self(category: .unknown)
+        }
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_: GeneratedContent.ParsingError) -> Self {
+        Self(category: .decodingFailure)
+    }
+
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    static func project(_ capability: LanguageModelCapabilities.Capability) -> Capability {
+        if capability == .vision {
+            return .vision
+        }
+        if capability == .guidedGeneration {
+            return .guidedGeneration
+        }
+        if capability == .reasoning {
+            return .reasoning
+        }
+        if capability == .toolCalling {
+            return .toolCalling
+        }
+        return .unknown
+    }
+    #endif
+}

--- a/Sources/FoundationModelsKit/Errors/FoundationModelsKitError.swift
+++ b/Sources/FoundationModelsKit/Errors/FoundationModelsKitError.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public enum FoundationModelsKitError: LocalizedError, Sendable, Equatable {
+  case invalidRequest(String)
+  case unavailableCapability(String)
+  case providerFailure(String)
+  case unsupportedEnvironment(String)
+
+  public var errorDescription: String? {
+    switch self {
+    case .invalidRequest(let message):
+      return "Invalid request: \(message)"
+    case .unavailableCapability(let message):
+      return "Unavailable capability: \(message)"
+    case .providerFailure(let message):
+      return "Provider failure: \(message)"
+    case .unsupportedEnvironment(let message):
+      return "Unsupported environment: \(message)"
+    }
+  }
+}

--- a/Sources/FoundationModelsKit/Requests/FoundationModelDynamicSchemaGenerationRequest.swift
+++ b/Sources/FoundationModelsKit/Requests/FoundationModelDynamicSchemaGenerationRequest.swift
@@ -1,0 +1,36 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelDynamicSchemaGenerationRequest: FoundationModelCapabilityRequest, Sendable {
+    public let prompt: String
+    public let schema: GenerationSchema
+    public let systemPrompt: String?
+    public let modelUseCase: FoundationModelUseCase
+    public let guardrails: FoundationModelGuardrails?
+    public let adapterURL: URL?
+    public let generationOptions: FoundationModelGenerationOptions?
+    public let includeSchemaInPrompt: Bool
+    public let context: FoundationModelInvocationContext
+
+    public init(
+        prompt: String,
+        schema: GenerationSchema,
+        systemPrompt: String? = nil,
+        modelUseCase: FoundationModelUseCase = .general,
+        guardrails: FoundationModelGuardrails? = nil,
+        adapterURL: URL? = nil,
+        generationOptions: FoundationModelGenerationOptions? = nil,
+        includeSchemaInPrompt: Bool = true,
+        context: FoundationModelInvocationContext
+    ) {
+        self.prompt = prompt
+        self.schema = schema
+        self.systemPrompt = systemPrompt
+        self.modelUseCase = modelUseCase
+        self.guardrails = guardrails
+        self.adapterURL = adapterURL
+        self.generationOptions = generationOptions
+        self.includeSchemaInPrompt = includeSchemaInPrompt
+        self.context = context
+    }
+}

--- a/Sources/FoundationModelsKit/Requests/FoundationModelInvocationContext.swift
+++ b/Sources/FoundationModelsKit/Requests/FoundationModelInvocationContext.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum FoundationModelInvocationSource: String, Sendable, Hashable, Codable {
+    case app
+    case appIntent
+    case cli
+    case automation
+    case unknown
+}
+
+public struct FoundationModelInvocationContext: Sendable, Hashable, Codable {
+    public let source: FoundationModelInvocationSource
+    public let localeIdentifier: String?
+    public let correlationID: UUID
+
+    public init(
+        source: FoundationModelInvocationSource,
+        localeIdentifier: String? = nil,
+        correlationID: UUID = UUID()
+    ) {
+        self.source = source
+        self.localeIdentifier = localeIdentifier
+        self.correlationID = correlationID
+    }
+}

--- a/Sources/FoundationModelsKit/Requests/FoundationModelStreamingTextGenerationRequest.swift
+++ b/Sources/FoundationModelsKit/Requests/FoundationModelStreamingTextGenerationRequest.swift
@@ -1,0 +1,30 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelStreamingTextGenerationRequest: FoundationModelCapabilityRequest, Sendable {
+    public let prompt: String
+    public let systemPrompt: String?
+    public let modelUseCase: FoundationModelUseCase
+    public let guardrails: FoundationModelGuardrails?
+    public let adapterURL: URL?
+    public let generationOptions: FoundationModelGenerationOptions?
+    public let context: FoundationModelInvocationContext
+
+    public init(
+        prompt: String,
+        systemPrompt: String? = nil,
+        modelUseCase: FoundationModelUseCase = .general,
+        guardrails: FoundationModelGuardrails? = nil,
+        adapterURL: URL? = nil,
+        generationOptions: FoundationModelGenerationOptions? = nil,
+        context: FoundationModelInvocationContext
+    ) {
+        self.prompt = prompt
+        self.systemPrompt = systemPrompt
+        self.modelUseCase = modelUseCase
+        self.guardrails = guardrails
+        self.adapterURL = adapterURL
+        self.generationOptions = generationOptions
+        self.context = context
+    }
+}

--- a/Sources/FoundationModelsKit/Requests/FoundationModelStructuredGenerationRequest.swift
+++ b/Sources/FoundationModelsKit/Requests/FoundationModelStructuredGenerationRequest.swift
@@ -1,0 +1,33 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelStructuredGenerationRequest<Output: Generable & Sendable>: FoundationModelCapabilityRequest, Sendable {
+    public let prompt: String
+    public let systemPrompt: String?
+    public let modelUseCase: FoundationModelUseCase
+    public let guardrails: FoundationModelGuardrails?
+    public let adapterURL: URL?
+    public let generationOptions: FoundationModelGenerationOptions?
+    public let includeSchemaInPrompt: Bool
+    public let context: FoundationModelInvocationContext
+
+    public init(
+        prompt: String,
+        systemPrompt: String? = nil,
+        modelUseCase: FoundationModelUseCase = .general,
+        guardrails: FoundationModelGuardrails? = nil,
+        adapterURL: URL? = nil,
+        generationOptions: FoundationModelGenerationOptions? = nil,
+        includeSchemaInPrompt: Bool = true,
+        context: FoundationModelInvocationContext
+    ) {
+        self.prompt = prompt
+        self.systemPrompt = systemPrompt
+        self.modelUseCase = modelUseCase
+        self.guardrails = guardrails
+        self.adapterURL = adapterURL
+        self.generationOptions = generationOptions
+        self.includeSchemaInPrompt = includeSchemaInPrompt
+        self.context = context
+    }
+}

--- a/Sources/FoundationModelsKit/Requests/FoundationModelTextGenerationRequest.swift
+++ b/Sources/FoundationModelsKit/Requests/FoundationModelTextGenerationRequest.swift
@@ -1,0 +1,28 @@
+import Foundation
+public struct FoundationModelTextGenerationRequest: FoundationModelCapabilityRequest, Sendable {
+    public let prompt: String
+    public let systemPrompt: String?
+    public let modelUseCase: FoundationModelUseCase
+    public let guardrails: FoundationModelGuardrails?
+    public let adapterURL: URL?
+    public let generationOptions: FoundationModelGenerationOptions?
+    public let context: FoundationModelInvocationContext
+
+    public init(
+        prompt: String,
+        systemPrompt: String? = nil,
+        modelUseCase: FoundationModelUseCase = .general,
+        guardrails: FoundationModelGuardrails? = nil,
+        adapterURL: URL? = nil,
+        generationOptions: FoundationModelGenerationOptions? = nil,
+        context: FoundationModelInvocationContext
+    ) {
+        self.prompt = prompt
+        self.systemPrompt = systemPrompt
+        self.modelUseCase = modelUseCase
+        self.guardrails = guardrails
+        self.adapterURL = adapterURL
+        self.generationOptions = generationOptions
+        self.context = context
+    }
+}

--- a/Sources/FoundationModelsKit/Results/FoundationModelAvailability.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelAvailability.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public enum FoundationModelAvailabilityUnavailableReason: String, Sendable, Hashable, Codable {
+    case deviceNotEligible
+    case appleIntelligenceNotEnabled
+    case modelNotReady
+    case unknown
+}
+
+public struct FoundationModelAvailability: FoundationModelCapabilityResult, Sendable, Hashable, Codable {
+    public let isAvailable: Bool
+    public let reason: FoundationModelAvailabilityUnavailableReason?
+    public let metadata: FoundationModelExecutionMetadata
+
+    public init(
+        isAvailable: Bool,
+        reason: FoundationModelAvailabilityUnavailableReason? = nil,
+        metadata: FoundationModelExecutionMetadata = FoundationModelExecutionMetadata()
+    ) {
+        self.isAvailable = isAvailable
+        self.reason = reason
+        self.metadata = metadata
+    }
+}

--- a/Sources/FoundationModelsKit/Results/FoundationModelDynamicSchemaGenerationResult.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelDynamicSchemaGenerationResult.swift
@@ -1,0 +1,15 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelDynamicSchemaGenerationResult: FoundationModelCapabilityResult, Sendable {
+    public let output: GeneratedContent
+    public let metadata: FoundationModelExecutionMetadata
+
+    public init(
+        output: GeneratedContent,
+        metadata: FoundationModelExecutionMetadata = FoundationModelExecutionMetadata()
+    ) {
+        self.output = output
+        self.metadata = metadata
+    }
+}

--- a/Sources/FoundationModelsKit/Results/FoundationModelExecutionMetadata.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelExecutionMetadata.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct FoundationModelExecutionMetadata: FoundationModelCapabilityResult, Sendable, Hashable, Codable {
+    public let provider: String?
+    public let modelIdentifier: String?
+    public let tokenCount: Int?
+
+    public init(
+        provider: String? = nil,
+        modelIdentifier: String? = nil,
+        tokenCount: Int? = nil
+    ) {
+        self.provider = provider
+        self.modelIdentifier = modelIdentifier
+        self.tokenCount = tokenCount
+    }
+}

--- a/Sources/FoundationModelsKit/Results/FoundationModelQuotaUsage.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelQuotaUsage.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public enum FoundationModelQuotaStatus: String, Sendable, Hashable, Codable {
+    case notApplicable
+    case unavailable
+    case belowLimit
+    case approachingLimit
+    case limitReached
+    case unsupported
+}
+
+public struct FoundationModelQuotaUsage: FoundationModelCapabilityResult, Sendable, Hashable, Codable {
+    public let runtime: FoundationModelRuntime
+    public let status: FoundationModelQuotaStatus
+    public let resetDate: Date?
+    public let canRequestLimitIncrease: Bool
+    public let unavailableReason: FoundationModelRuntimeUnavailableReason?
+    public let metadata: FoundationModelExecutionMetadata
+
+    public init(
+        runtime: FoundationModelRuntime,
+        status: FoundationModelQuotaStatus,
+        resetDate: Date? = nil,
+        canRequestLimitIncrease: Bool = false,
+        unavailableReason: FoundationModelRuntimeUnavailableReason? = nil,
+        metadata: FoundationModelExecutionMetadata = FoundationModelExecutionMetadata()
+    ) {
+        self.runtime = runtime
+        self.status = status
+        self.resetDate = resetDate
+        self.canRequestLimitIncrease = canRequestLimitIncrease
+        self.unavailableReason = unavailableReason
+        self.metadata = metadata
+    }
+}

--- a/Sources/FoundationModelsKit/Results/FoundationModelRuntimeStatus.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelRuntimeStatus.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+public enum FoundationModelRuntimeUnavailableReason: String, Sendable, Hashable, Codable {
+    case deviceNotEligible
+    case appleIntelligenceNotEnabled
+    case modelNotReady
+    case systemNotReady
+    case unsupportedOperatingSystem
+    case unsupportedToolchain
+    case missingEntitlement
+    case unknown
+}
+
+public enum FoundationModelRuntimeAuthorization: String, Sendable, Hashable, Codable {
+    case notRequired
+    case granted
+    case missing
+    case unknown
+}
+
+public struct FoundationModelRuntimeStatus: FoundationModelCapabilityResult, Sendable, Hashable, Codable {
+    public let runtime: FoundationModelRuntime
+    public let isSupported: Bool
+    public let isAvailable: Bool
+    public let isRunnableInCurrentProcess: Bool
+    public let authorization: FoundationModelRuntimeAuthorization
+    public let reason: FoundationModelRuntimeUnavailableReason?
+    public let metadata: FoundationModelExecutionMetadata
+
+    public init(
+        runtime: FoundationModelRuntime,
+        isSupported: Bool = true,
+        isAvailable: Bool,
+        authorization: FoundationModelRuntimeAuthorization = .notRequired,
+        reason: FoundationModelRuntimeUnavailableReason? = nil,
+        metadata: FoundationModelExecutionMetadata = FoundationModelExecutionMetadata()
+    ) {
+        self.runtime = runtime
+        self.isSupported = isSupported
+        self.isAvailable = isAvailable
+        let hasRequiredAuthorization = authorization == .granted
+            || (runtime == .onDevice && authorization == .notRequired)
+        self.isRunnableInCurrentProcess = isSupported
+            && isAvailable
+            && hasRequiredAuthorization
+        self.authorization = authorization
+        self.reason = reason ?? Self.authorizationReason(
+            runtime: runtime,
+            authorization: authorization
+        )
+        self.metadata = metadata
+    }
+
+    private static func authorizationReason(
+        runtime: FoundationModelRuntime,
+        authorization: FoundationModelRuntimeAuthorization
+    ) -> FoundationModelRuntimeUnavailableReason? {
+        guard runtime == .privateCloudCompute else { return nil }
+        switch authorization {
+        case .missing:
+            return .missingEntitlement
+        case .unknown, .notRequired:
+            return .unknown
+        case .granted:
+            return nil
+        }
+    }
+}

--- a/Sources/FoundationModelsKit/Results/FoundationModelRuntimeStatus.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelRuntimeStatus.swift
@@ -27,6 +27,16 @@ public struct FoundationModelRuntimeStatus: FoundationModelCapabilityResult, Sen
     public let reason: FoundationModelRuntimeUnavailableReason?
     public let metadata: FoundationModelExecutionMetadata
 
+    enum CodingKeys: String, CodingKey {
+        case runtime
+        case isSupported
+        case isAvailable
+        case isRunnableInCurrentProcess
+        case authorization
+        case reason
+        case metadata
+    }
+
     public init(
         runtime: FoundationModelRuntime,
         isSupported: Bool = true,
@@ -49,6 +59,34 @@ public struct FoundationModelRuntimeStatus: FoundationModelCapabilityResult, Sen
             authorization: authorization
         )
         self.metadata = metadata
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let runtime = try container.decode(FoundationModelRuntime.self, forKey: .runtime)
+        let isSupported = try container.decodeIfPresent(Bool.self, forKey: .isSupported) ?? true
+        let isAvailable = try container.decode(Bool.self, forKey: .isAvailable)
+        let authorization = try container.decodeIfPresent(
+            FoundationModelRuntimeAuthorization.self,
+            forKey: .authorization
+        ) ?? .notRequired
+        let reason = try container.decodeIfPresent(
+            FoundationModelRuntimeUnavailableReason.self,
+            forKey: .reason
+        )
+        let metadata = try container.decodeIfPresent(
+            FoundationModelExecutionMetadata.self,
+            forKey: .metadata
+        ) ?? FoundationModelExecutionMetadata()
+
+        self.init(
+            runtime: runtime,
+            isSupported: isSupported,
+            isAvailable: isAvailable,
+            authorization: authorization,
+            reason: reason,
+            metadata: metadata
+        )
     }
 
     private static func authorizationReason(

--- a/Sources/FoundationModelsKit/Results/FoundationModelStructuredGenerationResult.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelStructuredGenerationResult.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct FoundationModelStructuredGenerationResult<Output: Sendable>: FoundationModelCapabilityResult, Sendable {
+    public let output: Output
+    public let metadata: FoundationModelExecutionMetadata
+
+    public init(output: Output, metadata: FoundationModelExecutionMetadata = FoundationModelExecutionMetadata()) {
+        self.output = output
+        self.metadata = metadata
+    }
+}

--- a/Sources/FoundationModelsKit/Results/FoundationModelSupportedLanguages.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelSupportedLanguages.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public struct FoundationModelSupportedLanguage: Sendable, Hashable, Codable, Identifiable {
+    public let identifier: String
+    public let languageCode: String
+    public let regionCode: String?
+
+    public var id: String { identifier }
+
+    public init(identifier: String, languageCode: String, regionCode: String?) {
+        self.identifier = identifier
+        self.languageCode = languageCode
+        self.regionCode = regionCode
+    }
+}
+
+public struct FoundationModelSupportedLanguages: FoundationModelCapabilityResult, Sendable, Hashable, Codable {
+    public let languages: [FoundationModelSupportedLanguage]
+    public let metadata: FoundationModelExecutionMetadata
+
+    public init(
+        languages: [FoundationModelSupportedLanguage],
+        metadata: FoundationModelExecutionMetadata = FoundationModelExecutionMetadata()
+    ) {
+        self.languages = languages
+        self.metadata = metadata
+    }
+}
+
+public extension FoundationModelSupportedLanguage {
+    func displayName(in locale: Locale = .current) -> String {
+        let languageName = locale.localizedString(forLanguageCode: languageCode) ?? languageCode
+
+        if let regionCode, !regionCode.isEmpty {
+            return "\(languageName) (\(languageCode)-\(regionCode))"
+        }
+
+        return languageName
+    }
+}

--- a/Sources/FoundationModelsKit/Results/FoundationModelTextGenerationResult.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelTextGenerationResult.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct FoundationModelTextGenerationResult: FoundationModelCapabilityResult, Sendable, Hashable {
+    public let content: String
+    public let metadata: FoundationModelExecutionMetadata
+
+    public init(content: String, metadata: FoundationModelExecutionMetadata = FoundationModelExecutionMetadata()) {
+        self.content = content
+        self.metadata = metadata
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelAvailabilityChecking.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelAvailabilityChecking.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+public protocol FoundationModelAvailabilityChecking: Sendable {
+    func currentAvailability() -> FoundationModelAvailability
+    func currentAvailability(useCase: FoundationModelUseCase) -> FoundationModelAvailability
+}
+
+public extension FoundationModelAvailabilityChecking {
+    func currentAvailability(useCase _: FoundationModelUseCase) -> FoundationModelAvailability {
+        currentAvailability()
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationConfiguration.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationConfiguration.swift
@@ -1,0 +1,57 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelConversationConfiguration {
+    public var baseInstructions: String
+    public var summaryInstructions: String
+    public var summaryPromptPreamble: String
+    public var conversationUserLabel: String
+    public var conversationAssistantLabel: String
+    public var continuationNote: String
+    public var overflowResetMessage: String?
+    public var modelRuntime: FoundationModelRuntime
+    public var reasoningLevel: FoundationModelReasoningLevel
+    public var modelUseCase: FoundationModelUseCase
+    public var guardrails: FoundationModelGuardrails
+    public var tools: [any Tool]
+    public var enableSlidingWindow: Bool
+    public var windowThreshold: Double
+    public var targetWindowSize: Int
+    public var defaultMaxContextSize: Int
+
+    public init(
+        baseInstructions: String,
+        summaryInstructions: String,
+        summaryPromptPreamble: String,
+        conversationUserLabel: String,
+        conversationAssistantLabel: String,
+        continuationNote: String,
+        overflowResetMessage: String? = nil,
+        modelRuntime: FoundationModelRuntime = .onDevice,
+        reasoningLevel: FoundationModelReasoningLevel = .none,
+        modelUseCase: FoundationModelUseCase = .general,
+        guardrails: FoundationModelGuardrails = .default,
+        tools: [any Tool] = [],
+        enableSlidingWindow: Bool = false,
+        windowThreshold: Double = 0.70,
+        targetWindowSize: Int = 6_000,
+        defaultMaxContextSize: Int = 4_096
+    ) {
+        self.baseInstructions = baseInstructions
+        self.summaryInstructions = summaryInstructions
+        self.summaryPromptPreamble = summaryPromptPreamble
+        self.conversationUserLabel = conversationUserLabel
+        self.conversationAssistantLabel = conversationAssistantLabel
+        self.continuationNote = continuationNote
+        self.overflowResetMessage = overflowResetMessage
+        self.modelRuntime = modelRuntime
+        self.reasoningLevel = reasoningLevel
+        self.modelUseCase = modelUseCase
+        self.guardrails = guardrails
+        self.tools = tools
+        self.enableSlidingWindow = enableSlidingWindow
+        self.windowThreshold = windowThreshold
+        self.targetWindowSize = targetWindowSize
+        self.defaultMaxContextSize = defaultMaxContextSize
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationContextBuilder.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationContextBuilder.swift
@@ -15,6 +15,11 @@ public enum FoundationModelConversationContextBuilder {
             case .response:
                 guard let text = entry.textContentJoined() else { return nil }
                 return "\(assistantLabel) \(text)"
+            case .toolCalls(let toolCalls):
+                return "Tool Call: \(toolCalls.id)"
+            case .toolOutput(let toolOutput):
+                guard let text = entry.textContentJoined() else { return nil }
+                return "Tool Output (\(toolOutput.toolName)): \(text)"
             default:
                 return nil
             }

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationContextBuilder.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationContextBuilder.swift
@@ -1,0 +1,58 @@
+import Foundation
+import FoundationModels
+
+public enum FoundationModelConversationContextBuilder {
+    public static func conversationText(
+        from transcript: Transcript,
+        userLabel: String,
+        assistantLabel: String
+    ) -> String {
+        transcript.compactMap { entry in
+            switch entry {
+            case .prompt:
+                guard let text = entry.textContentJoined() else { return nil }
+                return "\(userLabel) \(text)"
+            case .response:
+                guard let text = entry.textContentJoined() else { return nil }
+                return "\(assistantLabel) \(text)"
+            default:
+                return nil
+            }
+        }
+        .joined(separator: "\n\n")
+    }
+
+    public static func contextInstructions(
+        baseInstructions: String,
+        summary: FoundationModelConversationSummary,
+        continuationNote: String? = nil
+    ) -> String {
+        var contextInstructions = """
+        \(baseInstructions)
+
+        You are continuing a conversation with a user. Here's a summary of your previous conversation:
+
+        CONVERSATION SUMMARY:
+        \(summary.summary)
+
+        KEY TOPICS DISCUSSED:
+        \(summary.keyTopics.foundationModelBulletList())
+
+        USER PREFERENCES/REQUESTS:
+        \(summary.userPreferences.foundationModelBulletList())
+        """
+
+        if let continuationNote, !continuationNote.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            contextInstructions += "\n\n\(continuationNote)"
+        }
+
+        return contextInstructions
+    }
+}
+
+private extension Array where Element == String {
+    func foundationModelBulletList(prefix: String = "• ") -> String {
+        guard !isEmpty else { return "\(prefix)None recorded yet" }
+        return map { "\(prefix)\($0)" }.joined(separator: "\n")
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
@@ -32,6 +32,10 @@ public final class FoundationModelConversationEngine {
     private let adapterURL: URL?
     private var activeStreamingTask: Task<String, Error>?
     private var activeResponseID: UUID?
+    #if DEBUG
+    var conversationSummaryOverride: (() async throws -> FoundationModelConversationSummary)?
+    var responseOverride: ((String, FoundationModelGenerationOptions?) async throws -> String)?
+    #endif
 
     public convenience init(configuration: FoundationModelConversationConfiguration) {
         self.init(
@@ -481,6 +485,12 @@ private extension FoundationModelConversationEngine {
         to prompt: String,
         generationOptions: FoundationModelGenerationOptions?
     ) async throws -> String {
+        #if DEBUG
+        if let responseOverride {
+            return try await responseOverride(prompt, generationOptions)
+        }
+        #endif
+
         if let generationOptions {
             #if compiler(>=6.4)
             if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
@@ -562,7 +572,7 @@ private extension FoundationModelConversationEngine {
                 onPartialResponse: onPartialResponse
             )
         case .oneShot:
-            response = try await respond(to: userMessage, generationOptions: generationOptions)
+            response = try await oneShotResponse(to: userMessage, generationOptions: generationOptions)
         }
 
         await updateTokenCount()
@@ -570,6 +580,12 @@ private extension FoundationModelConversationEngine {
     }
 
     func generateConversationSummary() async throws -> FoundationModelConversationSummary {
+        #if DEBUG
+        if let conversationSummaryOverride {
+            return try await conversationSummaryOverride()
+        }
+        #endif
+
         let summarySession = FoundationModelSessionFactory.makeSession(
             runtime: .onDevice,
             model: model,

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
@@ -185,6 +185,14 @@ public final class FoundationModelConversationEngine {
         return Transcript(entries: [instructionEntry] + nonInstructionEntries)
     }
 
+    func slidingWindowEntries(from transcript: Transcript) async -> [Transcript.Entry] {
+        let budgetedTranscript = slidingWindowTranscript(from: Array(transcript))
+        return await budgetedTranscript.entriesWithinTokenBudget(
+            effectiveTargetWindowSize,
+            using: model
+        )
+    }
+
     public func prewarm(promptPrefix: Prompt? = nil) {
         if let promptPrefix {
             session.prewarm(promptPrefix: promptPrefix)
@@ -306,10 +314,7 @@ private extension FoundationModelConversationEngine {
         isApplyingWindow = true
         notifyStateChange()
 
-        let windowEntries = await session.transcript.entriesWithinTokenBudget(
-            effectiveTargetWindowSize,
-            using: model
-        )
+        let windowEntries = await slidingWindowEntries(from: session.transcript)
         let transcript = slidingWindowTranscript(from: windowEntries)
 
         session = LanguageModelSession(model: model, transcript: transcript)

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
@@ -20,8 +20,15 @@ public final class FoundationModelConversationEngine {
     public var guardrails: FoundationModelGuardrails {
         configuration.guardrails
     }
+    var currentSessionInstructions: String {
+        sessionInstructions
+    }
+    var effectiveTargetWindowSize: Int {
+        max(1, min(configuration.targetWindowSize, maxContextSize))
+    }
     private var configuration: FoundationModelConversationConfiguration
     private var model: SystemLanguageModel
+    private var sessionInstructions: String
     private let adapterURL: URL?
     private var activeStreamingTask: Task<String, Error>?
     private var activeResponseID: UUID?
@@ -68,13 +75,14 @@ public final class FoundationModelConversationEngine {
     ) {
         self.configuration = configuration
         self.model = model
+        self.sessionInstructions = configuration.baseInstructions
         self.adapterURL = adapterURL
         self.maxContextSize = configuration.defaultMaxContextSize
         self.session = FoundationModelSessionFactory.makeSession(
             runtime: configuration.modelRuntime,
             model: model,
             tools: configuration.tools,
-            instructions: configuration.baseInstructions
+            instructions: sessionInstructions
         )
     }
 
@@ -98,6 +106,7 @@ public final class FoundationModelConversationEngine {
     ) {
         if let baseInstructions {
             configuration.baseInstructions = baseInstructions
+            sessionInstructions = baseInstructions
         }
         if let modelRuntime, adapterURL == nil {
             configuration.modelRuntime = modelRuntime
@@ -133,6 +142,26 @@ public final class FoundationModelConversationEngine {
         activeStreamingTask?.cancel()
         activeStreamingTask = nil
         activeResponseID = nil
+    }
+
+    func applyRecoveredConversationSummary(_ summary: FoundationModelConversationSummary) {
+        let contextInstructions = FoundationModelConversationContextBuilder.contextInstructions(
+            baseInstructions: configuration.baseInstructions,
+            summary: summary,
+            continuationNote: configuration.continuationNote
+        )
+        sessionInstructions = contextInstructions
+
+        session = FoundationModelSessionFactory.makeSession(
+            runtime: configuration.modelRuntime,
+            model: model,
+            tools: configuration.tools,
+            instructions: sessionInstructions
+        )
+        sessionCount += 1
+        currentTokenCount = 0
+        currentTokenUsage = nil
+        notifyStateChange()
     }
 
     public func prewarm(promptPrefix: Prompt? = nil) {
@@ -231,7 +260,7 @@ private extension FoundationModelConversationEngine {
             runtime: configuration.modelRuntime,
             model: model,
             tools: configuration.tools,
-            instructions: configuration.baseInstructions
+            instructions: sessionInstructions
         )
         notifyStateChange()
     }
@@ -257,7 +286,7 @@ private extension FoundationModelConversationEngine {
         notifyStateChange()
 
         let windowEntries = await session.transcript.entriesWithinTokenBudget(
-            configuration.targetWindowSize,
+            effectiveTargetWindowSize,
             using: model
         )
         let transcript = Transcript(entries: windowEntries)
@@ -481,7 +510,7 @@ private extension FoundationModelConversationEngine {
 
         do {
             let summary = try await generateConversationSummary()
-            createNewSession(with: summary)
+            applyRecoveredConversationSummary(summary)
         } catch is CancellationError {
             throw CancellationError()
         } catch {
@@ -538,31 +567,13 @@ private extension FoundationModelConversationEngine {
         return summaryResponse.content
     }
 
-    func createNewSession(with summary: FoundationModelConversationSummary) {
-        let contextInstructions = FoundationModelConversationContextBuilder.contextInstructions(
-            baseInstructions: configuration.baseInstructions,
-            summary: summary,
-            continuationNote: configuration.continuationNote
-        )
-
-        session = FoundationModelSessionFactory.makeSession(
-            runtime: configuration.modelRuntime,
-            model: model,
-            tools: configuration.tools,
-            instructions: contextInstructions
-        )
-        sessionCount += 1
-        currentTokenCount = 0
-        currentTokenUsage = nil
-        notifyStateChange()
-    }
-
     func createFreshSessionAfterOverflow() {
+        sessionInstructions = configuration.baseInstructions
         session = FoundationModelSessionFactory.makeSession(
             runtime: configuration.modelRuntime,
             model: model,
             tools: configuration.tools,
-            instructions: configuration.baseInstructions
+            instructions: sessionInstructions
         )
         sessionCount += 1
         currentTokenCount = 0

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
@@ -92,6 +92,7 @@ public final class FoundationModelConversationEngine {
         notifyStateChange()
     }
     public func setReasoningLevel(_ level: FoundationModelReasoningLevel) {
+        guard adapterURL == nil else { return }
         guard configuration.reasoningLevel != level else { return }
         configuration.reasoningLevel = level
         notifyStateChange()

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
@@ -73,6 +73,8 @@ public final class FoundationModelConversationEngine {
         model: SystemLanguageModel,
         adapterURL: URL?
     ) {
+        var configuration = configuration
+        configuration.modelRuntime = FoundationModelSessionFactory.resolvedRuntime(configuration.modelRuntime)
         self.configuration = configuration
         self.model = model
         self.sessionInstructions = configuration.baseInstructions
@@ -110,7 +112,7 @@ public final class FoundationModelConversationEngine {
             sessionInstructions = baseInstructions
         }
         if let modelRuntime, adapterURL == nil {
-            configuration.modelRuntime = modelRuntime
+            configuration.modelRuntime = FoundationModelSessionFactory.resolvedRuntime(modelRuntime)
         }
         if let reasoningLevel, adapterURL == nil {
             configuration.reasoningLevel = reasoningLevel

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
@@ -164,6 +164,27 @@ public final class FoundationModelConversationEngine {
         notifyStateChange()
     }
 
+    func slidingWindowTranscript(from entries: [Transcript.Entry]) -> Transcript {
+        let trimmedInstructions = sessionInstructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedInstructions.isEmpty else {
+            return Transcript(entries: entries)
+        }
+
+        let nonInstructionEntries = entries.filter { entry in
+            if case .instructions = entry {
+                return false
+            }
+            return true
+        }
+        let instructionEntry = Transcript.Entry.instructions(
+            Transcript.Instructions(
+                segments: [.text(Transcript.TextSegment(content: trimmedInstructions))],
+                toolDefinitions: []
+            )
+        )
+        return Transcript(entries: [instructionEntry] + nonInstructionEntries)
+    }
+
     public func prewarm(promptPrefix: Prompt? = nil) {
         if let promptPrefix {
             session.prewarm(promptPrefix: promptPrefix)
@@ -289,7 +310,7 @@ private extension FoundationModelConversationEngine {
             effectiveTargetWindowSize,
             using: model
         )
-        let transcript = Transcript(entries: windowEntries)
+        let transcript = slidingWindowTranscript(from: windowEntries)
 
         session = LanguageModelSession(model: model, transcript: transcript)
         sessionCount += 1

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationEngine.swift
@@ -1,0 +1,598 @@
+import Foundation
+import FoundationModels
+
+@MainActor
+public final class FoundationModelConversationEngine {
+    public var onStateChange: (@MainActor () -> Void)?
+    public private(set) var session: LanguageModelSession
+    public private(set) var sessionCount: Int = 1
+    public private(set) var currentTokenCount: Int = 0
+    public private(set) var currentTokenUsage: ModelTokenUsage?
+    public private(set) var maxContextSize: Int
+    public private(set) var isSummarizing: Bool = false
+    public private(set) var isApplyingWindow: Bool = false
+    public var modelRuntime: FoundationModelRuntime {
+        configuration.modelRuntime
+    }
+    public var reasoningLevel: FoundationModelReasoningLevel {
+        configuration.reasoningLevel
+    }
+    public var guardrails: FoundationModelGuardrails {
+        configuration.guardrails
+    }
+    private var configuration: FoundationModelConversationConfiguration
+    private var model: SystemLanguageModel
+    private let adapterURL: URL?
+    private var activeStreamingTask: Task<String, Error>?
+    private var activeResponseID: UUID?
+
+    public convenience init(configuration: FoundationModelConversationConfiguration) {
+        self.init(
+            configuration: configuration,
+            model: SystemLanguageModel(
+                useCase: configuration.modelUseCase.foundationModelsValue,
+                guardrails: configuration.guardrails.foundationModelsValue
+            ),
+            adapterURL: nil
+        )
+    }
+
+    public convenience init(
+        configuration: FoundationModelConversationConfiguration,
+        adapterURL: URL
+    ) throws {
+        guard configuration.modelRuntime == .onDevice else {
+            throw FoundationModelsKitError.invalidRequest(
+                "Foundation Models adapters only support the on-device runtime."
+            )
+        }
+        guard configuration.reasoningLevel == .none else {
+            throw FoundationModelsKitError.invalidRequest(
+                "Foundation Models adapters do not support Private Cloud Compute reasoning levels."
+            )
+        }
+        self.init(
+            configuration: configuration,
+            model: try FoundationModelsModelFactory.makeModel(
+                guardrails: configuration.guardrails,
+                adapterURL: adapterURL
+            ),
+            adapterURL: adapterURL
+        )
+    }
+
+    init(
+        configuration: FoundationModelConversationConfiguration,
+        model: SystemLanguageModel,
+        adapterURL: URL?
+    ) {
+        self.configuration = configuration
+        self.model = model
+        self.adapterURL = adapterURL
+        self.maxContextSize = configuration.defaultMaxContextSize
+        self.session = FoundationModelSessionFactory.makeSession(
+            runtime: configuration.modelRuntime,
+            model: model,
+            tools: configuration.tools,
+            instructions: configuration.baseInstructions
+        )
+    }
+
+    public func setMaxContextSize(_ value: Int) {
+        guard value > 0 else { return }
+        maxContextSize = value
+        notifyStateChange()
+    }
+    public func setReasoningLevel(_ level: FoundationModelReasoningLevel) {
+        guard configuration.reasoningLevel != level else { return }
+        configuration.reasoningLevel = level
+        notifyStateChange()
+    }
+
+    public func rebuild(
+        baseInstructions: String? = nil,
+        modelRuntime: FoundationModelRuntime? = nil,
+        reasoningLevel: FoundationModelReasoningLevel? = nil,
+        guardrails: FoundationModelGuardrails? = nil,
+        tools: [any Tool]? = nil
+    ) {
+        if let baseInstructions {
+            configuration.baseInstructions = baseInstructions
+        }
+        if let modelRuntime, adapterURL == nil {
+            configuration.modelRuntime = modelRuntime
+        }
+        if let reasoningLevel, adapterURL == nil {
+            configuration.reasoningLevel = reasoningLevel
+        }
+        if let guardrails, adapterURL == nil {
+            configuration.guardrails = guardrails
+        }
+        if let tools {
+            configuration.tools = tools
+        }
+        if adapterURL != nil {
+            configuration.modelRuntime = .onDevice
+            configuration.reasoningLevel = .none
+            configuration.guardrails = .default
+        }
+
+        if adapterURL == nil {
+            model = SystemLanguageModel(
+                useCase: configuration.modelUseCase.foundationModelsValue,
+                guardrails: configuration.guardrails.foundationModelsValue
+            )
+        }
+        resetSession()
+    }
+
+    public func clear() {
+        resetSession()
+    }
+    public func cancelActiveResponse() {
+        activeStreamingTask?.cancel()
+        activeStreamingTask = nil
+        activeResponseID = nil
+    }
+
+    public func prewarm(promptPrefix: Prompt? = nil) {
+        if let promptPrefix {
+            session.prewarm(promptPrefix: promptPrefix)
+        } else {
+            session.prewarm()
+        }
+    }
+    public func prewarm(withPromptPrefix promptPrefix: String?) {
+        let trimmedPrefix = promptPrefix?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let trimmedPrefix, !trimmedPrefix.isEmpty {
+            session.prewarm(promptPrefix: Prompt(trimmedPrefix))
+        } else {
+            session.prewarm()
+        }
+    }
+
+    public func sendStreamingMessage(
+        _ content: String,
+        generationOptions: FoundationModelGenerationOptions? = nil,
+        onPartialResponse: (@MainActor @Sendable (String) -> Void)? = nil
+    ) async throws -> String {
+        let prompt = try validatedPrompt(from: content)
+        do {
+            if await shouldApplyWindow() {
+                await applySlidingWindow()
+            }
+
+            let response = try await streamResponse(
+                to: prompt,
+                generationOptions: generationOptions,
+                onPartialResponse: onPartialResponse
+            )
+            await updateTokenCount()
+            return response
+        } catch where FoundationModelErrorProjection.isContextOverflow(error) {
+            return try await recoverFromContextOverflow(
+                userMessage: prompt,
+                generationOptions: generationOptions,
+                responseMode: .streaming,
+                onPartialResponse: onPartialResponse
+            )
+        }
+    }
+
+    public func sendMessage(
+        _ content: String,
+        generationOptions: FoundationModelGenerationOptions? = nil
+    ) async throws -> String {
+        let prompt = try validatedPrompt(from: content)
+        do {
+            if await shouldApplyWindow() {
+                await applySlidingWindow()
+            }
+
+            let response = try await oneShotResponse(
+                to: prompt,
+                generationOptions: generationOptions
+            )
+            await updateTokenCount()
+            return response
+        } catch where FoundationModelErrorProjection.isContextOverflow(error) {
+            return try await recoverFromContextOverflow(
+                userMessage: prompt,
+                generationOptions: generationOptions,
+                responseMode: .oneShot,
+                onPartialResponse: nil
+            )
+        }
+    }
+}
+
+private extension FoundationModelConversationEngine {
+    enum ResponseMode {
+        case streaming
+        case oneShot
+    }
+
+    func validatedPrompt(from content: String) throws -> String {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw FoundationModelsKitError.invalidRequest("Missing prompt")
+        }
+        return trimmed
+    }
+    func resetSession() {
+        cancelActiveResponse()
+        sessionCount = 1
+        currentTokenCount = 0
+        currentTokenUsage = nil
+        isSummarizing = false
+        isApplyingWindow = false
+        session = FoundationModelSessionFactory.makeSession(
+            runtime: configuration.modelRuntime,
+            model: model,
+            tools: configuration.tools,
+            instructions: configuration.baseInstructions
+        )
+        notifyStateChange()
+    }
+
+    func shouldApplyWindow() async -> Bool {
+        guard configuration.enableSlidingWindow, configuration.tools.isEmpty, configuration.modelRuntime == .onDevice else {
+            return false
+        }
+
+        return await session.transcript.isApproachingLimit(
+            threshold: configuration.windowThreshold,
+            maxTokens: maxContextSize,
+            using: model
+        )
+    }
+
+    func applySlidingWindow() async {
+        guard configuration.enableSlidingWindow, configuration.tools.isEmpty, configuration.modelRuntime == .onDevice else {
+            return
+        }
+
+        isApplyingWindow = true
+        notifyStateChange()
+
+        let windowEntries = await session.transcript.entriesWithinTokenBudget(
+            configuration.targetWindowSize,
+            using: model
+        )
+        let transcript = Transcript(entries: windowEntries)
+
+        session = LanguageModelSession(model: model, transcript: transcript)
+        sessionCount += 1
+        await updateTokenCount(usageSource: .context)
+
+        isApplyingWindow = false
+        notifyStateChange()
+    }
+
+    func updateTokenCount(usageSource: FoundationModelConversationTokenUsageSource = .accumulatedSession) async {
+        let snapshot = await foundationModelConversationTokenSnapshot(
+            session: session,
+            model: model,
+            runtime: configuration.modelRuntime,
+            usageSource: usageSource
+        )
+        currentTokenCount = snapshot.legacyTokenCount
+        currentTokenUsage = snapshot.usage
+        notifyStateChange()
+    }
+
+    func streamResponse(
+        to prompt: String,
+        generationOptions: FoundationModelGenerationOptions?,
+        onPartialResponse: (@MainActor @Sendable (String) -> Void)?
+    ) async throws -> String {
+        activeStreamingTask?.cancel()
+        let transcriptCountBeforeResponse = session.transcript.count
+        let task = Task<String, Error> { @MainActor [weak self] in
+            guard let self else {
+                throw CancellationError()
+            }
+
+            let latest = try await self.performStreamingResponse(
+                to: prompt,
+                generationOptions: generationOptions,
+                onPartialResponse: onPartialResponse
+            )
+            try Task.checkCancellation()
+            return latest.isEmpty
+                ? self.session.transcript.latestResponseText(after: transcriptCountBeforeResponse)
+                : latest
+        }
+
+        let responseID = UUID()
+        activeStreamingTask = task
+        activeResponseID = responseID
+        defer {
+            if activeResponseID == responseID {
+                activeStreamingTask = nil
+                activeResponseID = nil
+            }
+        }
+        return try await task.valuePropagatingCancellation()
+    }
+
+    func performStreamingResponse(
+        to prompt: String,
+        generationOptions: FoundationModelGenerationOptions?,
+        onPartialResponse: (@MainActor @Sendable (String) -> Void)?
+    ) async throws -> String {
+        if let generationOptions {
+            return try await streamWithGenerationOptions(
+                prompt: prompt,
+                generationOptions: generationOptions,
+                onPartialResponse: onPartialResponse
+            )
+        }
+
+        return try await streamWithoutGenerationOptions(
+            prompt: prompt,
+            onPartialResponse: onPartialResponse
+        )
+    }
+
+    func oneShotResponse(
+        to prompt: String,
+        generationOptions: FoundationModelGenerationOptions?
+    ) async throws -> String {
+        activeStreamingTask?.cancel()
+        let task = Task<String, Error> { @MainActor [weak self] in
+            guard let self else {
+                throw CancellationError()
+            }
+            let response = try await self.respond(to: prompt, generationOptions: generationOptions)
+            try Task.checkCancellation()
+            return response
+        }
+
+        let responseID = UUID()
+        activeStreamingTask = task
+        activeResponseID = responseID
+        defer {
+            if activeResponseID == responseID {
+                activeStreamingTask = nil
+                activeResponseID = nil
+            }
+        }
+        return try await task.valuePropagatingCancellation()
+    }
+
+    func streamWithGenerationOptions(
+        prompt: String,
+        generationOptions: FoundationModelGenerationOptions,
+        onPartialResponse: (@MainActor @Sendable (String) -> Void)?
+    ) async throws -> String {
+        var latest = ""
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *),
+           let contextOptions = contextOptions() {
+            for try await snapshot in session.streamResponse(
+                to: Prompt(prompt),
+                options: generationOptions.foundationModelsValue,
+                contextOptions: contextOptions
+            ) {
+                latest = snapshot.content
+                onPartialResponse?(snapshot.content)
+            }
+            return latest
+        }
+        #endif
+
+        for try await snapshot in session.streamResponse(
+            to: Prompt(prompt),
+            options: generationOptions.foundationModelsValue
+        ) {
+            latest = snapshot.content
+            onPartialResponse?(snapshot.content)
+        }
+        return latest
+    }
+
+    func streamWithoutGenerationOptions(
+        prompt: String,
+        onPartialResponse: (@MainActor @Sendable (String) -> Void)?
+    ) async throws -> String {
+        var latest = ""
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *),
+           let contextOptions = contextOptions() {
+            for try await snapshot in session.streamResponse(
+                to: Prompt(prompt),
+                contextOptions: contextOptions
+            ) {
+                latest = snapshot.content
+                onPartialResponse?(snapshot.content)
+            }
+            return latest
+        }
+        #endif
+
+        for try await snapshot in session.streamResponse(to: Prompt(prompt)) {
+            latest = snapshot.content
+            onPartialResponse?(snapshot.content)
+        }
+        return latest
+    }
+
+    func respond(
+        to prompt: String,
+        generationOptions: FoundationModelGenerationOptions?
+    ) async throws -> String {
+        if let generationOptions {
+            #if compiler(>=6.4)
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+                if let contextOptions = contextOptions() {
+                    return try await session.respond(
+                        to: Prompt(prompt),
+                        options: generationOptions.foundationModelsValue,
+                        contextOptions: contextOptions
+                    ).content
+                }
+
+                return try await session.respond(
+                    to: Prompt(prompt),
+                    options: generationOptions.foundationModelsValue
+                ).content
+            }
+            #endif
+
+            return try await session.respond(
+                to: Prompt(prompt),
+                options: generationOptions.foundationModelsValue
+            ).content
+        }
+
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            if let contextOptions = contextOptions() {
+                return try await session.respond(
+                    to: Prompt(prompt),
+                    contextOptions: contextOptions
+                ).content
+            }
+
+            return try await session.respond(
+                to: Prompt(prompt)
+            ).content
+        }
+        #endif
+
+        return try await session.respond(to: Prompt(prompt)).content
+    }
+
+    func recoverFromContextOverflow(
+        userMessage: String,
+        generationOptions: FoundationModelGenerationOptions?,
+        responseMode: ResponseMode,
+        onPartialResponse: (@MainActor @Sendable (String) -> Void)?
+    ) async throws -> String {
+        isSummarizing = true
+        notifyStateChange()
+
+        defer {
+            isSummarizing = false
+            notifyStateChange()
+        }
+
+        do {
+            let summary = try await generateConversationSummary()
+            createNewSession(with: summary)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            createFreshSessionAfterOverflow()
+
+            if let overflowResetMessage = trimmedOverflowResetMessage() {
+                onPartialResponse?(overflowResetMessage)
+                return overflowResetMessage
+            }
+
+            throw error
+        }
+
+        let response: String
+        switch responseMode {
+        case .streaming:
+            response = try await streamResponse(
+                to: userMessage,
+                generationOptions: generationOptions,
+                onPartialResponse: onPartialResponse
+            )
+        case .oneShot:
+            response = try await respond(to: userMessage, generationOptions: generationOptions)
+        }
+
+        await updateTokenCount()
+        return response
+    }
+
+    func generateConversationSummary() async throws -> FoundationModelConversationSummary {
+        let summarySession = FoundationModelSessionFactory.makeSession(
+            runtime: .onDevice,
+            model: model,
+            tools: [],
+            instructions: configuration.summaryInstructions
+        )
+
+        let conversationText = FoundationModelConversationContextBuilder.conversationText(
+            from: session.transcript,
+            userLabel: configuration.conversationUserLabel,
+            assistantLabel: configuration.conversationAssistantLabel
+        )
+        let summaryPrompt = """
+        \(configuration.summaryPromptPreamble)
+
+        \(conversationText)
+        """
+
+        let summaryResponse = try await summarySession.respond(
+            to: Prompt(summaryPrompt),
+            generating: FoundationModelConversationSummary.self
+        )
+
+        return summaryResponse.content
+    }
+
+    func createNewSession(with summary: FoundationModelConversationSummary) {
+        let contextInstructions = FoundationModelConversationContextBuilder.contextInstructions(
+            baseInstructions: configuration.baseInstructions,
+            summary: summary,
+            continuationNote: configuration.continuationNote
+        )
+
+        session = FoundationModelSessionFactory.makeSession(
+            runtime: configuration.modelRuntime,
+            model: model,
+            tools: configuration.tools,
+            instructions: contextInstructions
+        )
+        sessionCount += 1
+        currentTokenCount = 0
+        currentTokenUsage = nil
+        notifyStateChange()
+    }
+
+    func createFreshSessionAfterOverflow() {
+        session = FoundationModelSessionFactory.makeSession(
+            runtime: configuration.modelRuntime,
+            model: model,
+            tools: configuration.tools,
+            instructions: configuration.baseInstructions
+        )
+        sessionCount += 1
+        currentTokenCount = 0
+        currentTokenUsage = nil
+        notifyStateChange()
+    }
+
+    func trimmedOverflowResetMessage() -> String? {
+        guard let message = configuration.overflowResetMessage?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !message.isEmpty else {
+            return nil
+        }
+
+        return message
+    }
+
+    #if compiler(>=6.4)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    func contextOptions() -> ContextOptions? {
+        guard configuration.modelRuntime == .privateCloudCompute,
+              configuration.reasoningLevel != .none else {
+            return nil
+        }
+
+        return ContextOptions(reasoningLevel: configuration.reasoningLevel.foundationModelsValue)
+    }
+    #endif
+
+    func notifyStateChange() {
+        onStateChange?()
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationSummary.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationSummary.swift
@@ -1,0 +1,27 @@
+import Foundation
+import FoundationModels
+
+@Generable
+public struct FoundationModelConversationSummary: RuntimeCompatibleGenerable, Sendable {
+    @Guide(
+        description:
+            "A comprehensive summary of the conversation including the important context needed to continue it."
+    )
+    public let summary: String
+
+    @Guide(description: "The key topics, themes, or tasks discussed in the conversation.")
+    public let keyTopics: [String]
+
+    @Guide(description: "User preferences, goals, or requests that should carry into future turns.")
+    public let userPreferences: [String]
+
+    public init(
+        summary: String,
+        keyTopics: [String],
+        userPreferences: [String]
+    ) {
+        self.summary = summary
+        self.keyTopics = keyTopics
+        self.userPreferences = userPreferences
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationTokenAccounting.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationTokenAccounting.swift
@@ -1,0 +1,69 @@
+import FoundationModels
+
+struct FoundationModelConversationTokenSnapshot {
+    let legacyTokenCount: Int
+    let usage: ModelTokenUsage
+}
+
+enum FoundationModelConversationTokenUsageSource {
+    case context
+    case accumulatedSession
+}
+
+func foundationModelConversationTokenSnapshot(
+    session: LanguageModelSession,
+    model: SystemLanguageModel,
+    runtime: FoundationModelRuntime,
+    usageSource: FoundationModelConversationTokenUsageSource = .accumulatedSession
+) async -> FoundationModelConversationTokenSnapshot {
+    let contextUsage: ModelTokenUsage
+    switch runtime {
+    case .onDevice:
+        contextUsage = await session.transcript.tokenUsage(using: model)
+    case .privateCloudCompute:
+        contextUsage = ModelTokenUsage(
+            inputTokenCount: session.transcript.estimatedTokenCount,
+            measurement: .estimated
+        )
+    }
+
+    let observedSessionUsage: ModelTokenUsage?
+    switch usageSource {
+    case .context:
+        observedSessionUsage = nil
+    case .accumulatedSession:
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            observedSessionUsage = ModelTokenUsage(observing: session.usage, scope: .session)
+        } else {
+            observedSessionUsage = nil
+        }
+        #else
+        observedSessionUsage = nil
+        #endif
+    }
+
+    return foundationModelConversationTokenSnapshot(
+        contextUsage: contextUsage,
+        observedSessionUsage: observedSessionUsage,
+        usageSource: usageSource
+    )
+}
+
+func foundationModelConversationTokenSnapshot(
+    contextUsage: ModelTokenUsage,
+    observedSessionUsage: ModelTokenUsage?,
+    usageSource: FoundationModelConversationTokenUsageSource
+) -> FoundationModelConversationTokenSnapshot {
+    let resolvedUsage = switch usageSource {
+    case .context:
+        contextUsage
+    case .accumulatedSession:
+        observedSessionUsage ?? contextUsage
+    }
+
+    return FoundationModelConversationTokenSnapshot(
+        legacyTokenCount: contextUsage.totalTokenCount,
+        usage: resolvedUsage
+    )
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelConversationTokenAccounting.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelConversationTokenAccounting.swift
@@ -59,7 +59,12 @@ func foundationModelConversationTokenSnapshot(
     case .context:
         contextUsage
     case .accumulatedSession:
-        observedSessionUsage ?? contextUsage
+        if let observedSessionUsage,
+           observedSessionUsage.totalTokenCount > 0 || contextUsage.totalTokenCount == 0 {
+            observedSessionUsage
+        } else {
+            contextUsage
+        }
     }
 
     return FoundationModelConversationTokenSnapshot(

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelDynamicSchemaGenerating.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelDynamicSchemaGenerating.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol FoundationModelDynamicSchemaGenerating: Sendable {
+    func generate(for request: FoundationModelDynamicSchemaGenerationRequest) async throws -> FoundationModelDynamicSchemaGenerationResult
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelGenerationOptions.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelGenerationOptions.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public struct FoundationModelGenerationOptions: Sendable, Hashable, Codable {
+    public enum SamplingMode: Sendable, Hashable, Codable {
+        case greedy
+        case randomTop(Int, seed: UInt64? = nil)
+        case randomProbabilityThreshold(Double, seed: UInt64? = nil)
+    }
+
+    public let sampling: SamplingMode?
+    public let temperature: Double?
+    public let maximumResponseTokens: Int?
+
+    public init(
+        sampling: SamplingMode? = nil,
+        temperature: Double? = nil,
+        maximumResponseTokens: Int? = nil
+    ) {
+        self.sampling = sampling
+        self.temperature = temperature
+        self.maximumResponseTokens = maximumResponseTokens
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelGuardrails.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelGuardrails.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum FoundationModelGuardrails: String, Sendable, Hashable, Codable, CaseIterable {
+    case `default`
+    case permissiveContentTransformations
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelReasoningLevel.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelReasoningLevel.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public enum FoundationModelReasoningLevel: String, CaseIterable, Sendable, Hashable, Codable {
+    case none
+    case light
+    case moderate
+    case deep
+
+    public var displayName: String {
+        switch self {
+        case .none:
+            return String(localized: "None")
+        case .light:
+            return String(localized: "Light")
+        case .moderate:
+            return String(localized: "Moderate")
+        case .deep:
+            return String(localized: "Deep")
+        }
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .none:
+            return "brain"
+        case .light:
+            return "bolt"
+        case .moderate:
+            return "brain"
+        case .deep:
+            return "brain.head.profile"
+        }
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelRuntime.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelRuntime.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public enum FoundationModelRuntime: String, CaseIterable, Sendable, Hashable, Codable {
+    case onDevice
+    case privateCloudCompute
+
+    public var displayName: String {
+        switch self {
+        case .onDevice:
+            return String(localized: "On Device")
+        case .privateCloudCompute:
+            return String(localized: "Private Cloud Compute")
+        }
+    }
+
+    public var shortName: String {
+        switch self {
+        case .onDevice:
+            return String(localized: "On-device")
+        case .privateCloudCompute:
+            return "PCC"
+        }
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .onDevice:
+            return "iphone"
+        case .privateCloudCompute:
+            return "icloud"
+        }
+    }
+
+    public var requiresNewSessionOnSelection: Bool {
+        true
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelRuntimeInspecting.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelRuntimeInspecting.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public protocol FoundationModelRuntimeInspecting: Sendable {
+    func status(for runtime: FoundationModelRuntime) -> FoundationModelRuntimeStatus
+    func quotaUsage(for runtime: FoundationModelRuntime) -> FoundationModelQuotaUsage
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelSessionFactory.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelSessionFactory.swift
@@ -1,0 +1,85 @@
+import Foundation
+import FoundationModels
+
+enum FoundationModelSessionFactory {
+    static func makeSession(
+        runtime: FoundationModelRuntime,
+        model: SystemLanguageModel,
+        tools: [any Tool],
+        instructions: String
+    ) -> LanguageModelSession {
+        #if compiler(>=6.4)
+        if runtime == .privateCloudCompute {
+            if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+                return makePrivateCloudSession(
+                    tools: tools,
+                    instructions: instructions
+                )
+            }
+        }
+        #endif
+
+        return makeOnDeviceSession(
+            model: model,
+            tools: tools,
+            instructions: instructions
+        )
+    }
+
+    private static func makeOnDeviceSession(
+        model: SystemLanguageModel,
+        tools: [any Tool],
+        instructions: String
+    ) -> LanguageModelSession {
+        let trimmedInstructions = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !tools.isEmpty {
+            if trimmedInstructions.isEmpty {
+                return LanguageModelSession(model: model, tools: tools)
+            }
+            return LanguageModelSession(
+                model: model,
+                tools: tools,
+                instructions: Instructions(trimmedInstructions)
+            )
+        }
+
+        if trimmedInstructions.isEmpty {
+            return LanguageModelSession(model: model)
+        }
+
+        return LanguageModelSession(
+            model: model,
+            instructions: Instructions(trimmedInstructions)
+        )
+    }
+
+    #if compiler(>=6.4)
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    private static func makePrivateCloudSession(
+        tools: [any Tool],
+        instructions: String
+    ) -> LanguageModelSession {
+        let model = PrivateCloudComputeLanguageModel()
+        let trimmedInstructions = instructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !tools.isEmpty {
+            if trimmedInstructions.isEmpty {
+                return LanguageModelSession(model: model, tools: tools)
+            }
+            return LanguageModelSession(
+                model: model,
+                tools: tools,
+                instructions: Instructions(trimmedInstructions)
+            )
+        }
+
+        if trimmedInstructions.isEmpty {
+            return LanguageModelSession(model: model)
+        }
+
+        return LanguageModelSession(
+            model: model,
+            instructions: Instructions(trimmedInstructions)
+        )
+    }
+    #endif
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelSessionFactory.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelSessionFactory.swift
@@ -2,12 +2,30 @@ import Foundation
 import FoundationModels
 
 enum FoundationModelSessionFactory {
+    static func resolvedRuntime(_ runtime: FoundationModelRuntime) -> FoundationModelRuntime {
+        guard runtime == .privateCloudCompute else {
+            return runtime
+        }
+        return supportsPrivateCloudSessions ? .privateCloudCompute : .onDevice
+    }
+
+    private static var supportsPrivateCloudSessions: Bool {
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            return true
+        }
+        #endif
+        return false
+    }
+
     static func makeSession(
         runtime: FoundationModelRuntime,
         model: SystemLanguageModel,
         tools: [any Tool],
         instructions: String
     ) -> LanguageModelSession {
+        let runtime = resolvedRuntime(runtime)
+
         #if compiler(>=6.4)
         if runtime == .privateCloudCompute {
             if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelStreamingTextGenerating.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelStreamingTextGenerating.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+public protocol StreamingFoundationModelTextGenerating: Sendable {
+    func streamText(
+        for request: FoundationModelStreamingTextGenerationRequest,
+        onPartialResponse: @escaping @Sendable (String) async -> Void
+    ) async throws -> FoundationModelTextGenerationResult
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelStructuredGenerating.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelStructuredGenerating.swift
@@ -1,0 +1,9 @@
+import Foundation
+import FoundationModels
+
+public protocol FoundationModelStructuredGenerating: Sendable {
+    func generate<Output: Generable & Sendable>(
+        _ type: Output.Type,
+        for request: FoundationModelStructuredGenerationRequest<Output>
+    ) async throws -> FoundationModelStructuredGenerationResult<Output>
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelSupportedLanguageListing.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelSupportedLanguageListing.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public protocol FoundationModelSupportedLanguageListing: Sendable {
+    func supportedLanguages(locale: Locale) -> FoundationModelSupportedLanguages
+    func supportedLanguages(
+        useCase: FoundationModelUseCase,
+        locale: Locale
+    ) -> FoundationModelSupportedLanguages
+}
+
+public extension FoundationModelSupportedLanguageListing {
+    func supportedLanguages(
+        useCase _: FoundationModelUseCase,
+        locale: Locale
+    ) -> FoundationModelSupportedLanguages {
+        supportedLanguages(locale: locale)
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelTextGenerating.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelTextGenerating.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol FoundationModelTextGenerating: Sendable {
+    func generateText(for request: FoundationModelTextGenerationRequest) async throws -> FoundationModelTextGenerationResult
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelUseCase.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelUseCase.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum FoundationModelUseCase: String, Sendable, Hashable, Codable, CaseIterable {
+    case general
+    case contentTagging = "content-tagging"
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelsConfigurationAdapters.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelsConfigurationAdapters.swift
@@ -1,0 +1,73 @@
+import Foundation
+import FoundationModels
+
+extension FoundationModelUseCase {
+    public var foundationModelsValue: SystemLanguageModel.UseCase {
+        switch self {
+        case .general:
+            return .general
+        case .contentTagging:
+            return .contentTagging
+        }
+    }
+}
+
+extension FoundationModelGuardrails {
+    public var foundationModelsValue: SystemLanguageModel.Guardrails {
+        switch self {
+        case .default:
+            return .default
+        case .permissiveContentTransformations:
+            return .permissiveContentTransformations
+        }
+    }
+}
+
+extension FoundationModelGenerationOptions.SamplingMode {
+    public var foundationModelsValue: GenerationOptions.SamplingMode {
+        switch self {
+        case .greedy:
+            return .greedy
+        case .randomTop(let top, let seed):
+            return .random(top: top, seed: seed)
+        case .randomProbabilityThreshold(let threshold, let seed):
+            return .random(probabilityThreshold: threshold, seed: seed)
+        }
+    }
+}
+
+extension FoundationModelGenerationOptions {
+    public var foundationModelsValue: GenerationOptions {
+        #if compiler(>=6.4)
+        GenerationOptions(
+            samplingMode: sampling?.foundationModelsValue,
+            temperature: temperature,
+            maximumResponseTokens: maximumResponseTokens
+        )
+        #else
+        GenerationOptions(
+            sampling: sampling?.foundationModelsValue,
+            temperature: temperature,
+            maximumResponseTokens: maximumResponseTokens
+        )
+        #endif
+    }
+}
+
+#if compiler(>=6.4)
+extension FoundationModelReasoningLevel {
+    @available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+    var foundationModelsValue: ContextOptions.ReasoningLevel? {
+        switch self {
+        case .none:
+            return nil
+        case .light:
+            return .light
+        case .moderate:
+            return .moderate
+        case .deep:
+            return .deep
+        }
+    }
+}
+#endif

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelsDynamicSchemaGenerator.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelsDynamicSchemaGenerator.swift
@@ -1,0 +1,57 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelsDynamicSchemaGenerator: FoundationModelDynamicSchemaGenerating {
+    public init() {}
+
+    public func generate(for request: FoundationModelDynamicSchemaGenerationRequest) async throws -> FoundationModelDynamicSchemaGenerationResult {
+        let prompt = request.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw FoundationModelsKitError.invalidRequest("Missing prompt")
+        }
+
+        let model = try FoundationModelsModelFactory.makeModel(
+            useCase: request.modelUseCase,
+            guardrails: request.guardrails ?? .default,
+            adapterURL: request.adapterURL
+        )
+        let session: LanguageModelSession
+
+        if let systemPrompt = request.systemPrompt?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !systemPrompt.isEmpty {
+            session = LanguageModelSession(
+                model: model,
+                instructions: Instructions(systemPrompt)
+            )
+        } else {
+            session = LanguageModelSession(model: model)
+        }
+
+        let output: GeneratedContent
+        if let generationOptions = request.generationOptions {
+            output = try await session.respond(
+                to: Prompt(prompt),
+                schema: request.schema,
+                includeSchemaInPrompt: request.includeSchemaInPrompt,
+                options: generationOptions.foundationModelsValue
+            ).content
+        } else {
+            output = try await session.respond(
+                to: Prompt(prompt),
+                schema: request.schema,
+                includeSchemaInPrompt: request.includeSchemaInPrompt
+            ).content
+        }
+
+        let tokenCount = await session.transcript.tokenCount(using: model)
+
+        return FoundationModelDynamicSchemaGenerationResult(
+            output: output,
+            metadata: FoundationModelExecutionMetadata(
+                provider: "Foundation Models",
+                modelIdentifier: request.adapterURL?.lastPathComponent ?? request.modelUseCase.rawValue,
+                tokenCount: tokenCount
+            )
+        )
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelsModelAvailabilityChecker.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelsModelAvailabilityChecker.swift
@@ -1,0 +1,23 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelsModelAvailabilityChecker: FoundationModelAvailabilityChecking {
+    public init() {}
+
+    public func currentAvailability() -> FoundationModelAvailability {
+        currentAvailability(useCase: .general)
+    }
+
+    public func currentAvailability(
+        useCase: FoundationModelUseCase = .general
+    ) -> FoundationModelAvailability {
+        let model = SystemLanguageModel(
+            useCase: useCase.foundationModelsValue,
+            guardrails: FoundationModelGuardrails.default.foundationModelsValue
+        )
+        return FoundationModelsModelFactory.availabilityResult(
+            for: model,
+            modelIdentifier: useCase.rawValue
+        )
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelsModelFactory.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelsModelFactory.swift
@@ -1,0 +1,81 @@
+import Foundation
+import FoundationModels
+
+public enum FoundationModelsModelFactory {
+    public static func currentAvailability(
+        useCase: FoundationModelUseCase = .general,
+        guardrails: FoundationModelGuardrails = .default,
+        adapterURL: URL? = nil
+    ) throws -> FoundationModelAvailability {
+        let model = try makeModel(
+            useCase: useCase,
+            guardrails: guardrails,
+            adapterURL: adapterURL
+        )
+        return availabilityResult(
+            for: model,
+            modelIdentifier: adapterURL?.lastPathComponent ?? useCase.rawValue
+        )
+    }
+
+    public static func makeModel(
+        useCase: FoundationModelUseCase = .general,
+        guardrails: FoundationModelGuardrails = .default,
+        adapterURL: URL? = nil
+    ) throws -> SystemLanguageModel {
+        if let adapterURL {
+            guard guardrails == .default else {
+                throw FoundationModelsKitError.invalidRequest(
+                    "Foundation Models adapters only support the framework's default guardrails."
+                )
+            }
+            let adapter = try SystemLanguageModel.Adapter(fileURL: adapterURL)
+            return SystemLanguageModel(adapter: adapter)
+        }
+
+        return SystemLanguageModel(
+            useCase: useCase.foundationModelsValue,
+            guardrails: guardrails.foundationModelsValue
+        )
+    }
+
+    static func availabilityResult(
+        for model: SystemLanguageModel,
+        modelIdentifier: String
+    ) -> FoundationModelAvailability {
+        switch model.availability {
+        case .available:
+            return FoundationModelAvailability(
+                isAvailable: true,
+                metadata: FoundationModelExecutionMetadata(
+                    provider: "Foundation Models",
+                    modelIdentifier: modelIdentifier
+                )
+            )
+        case .unavailable(let reason):
+            return FoundationModelAvailability(
+                isAvailable: false,
+                reason: map(reason),
+                metadata: FoundationModelExecutionMetadata(
+                    provider: "Foundation Models",
+                    modelIdentifier: modelIdentifier
+                )
+            )
+        }
+    }
+
+    private static func map(
+        _ reason: SystemLanguageModel.Availability.UnavailableReason
+    ) -> FoundationModelAvailabilityUnavailableReason {
+        switch reason {
+        case .deviceNotEligible:
+            return .deviceNotEligible
+        case .appleIntelligenceNotEnabled:
+            return .appleIntelligenceNotEnabled
+        case .modelNotReady:
+            return .modelNotReady
+        @unknown default:
+            return .unknown
+        }
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelsRuntimeInspector.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelsRuntimeInspector.swift
@@ -1,0 +1,194 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelsRuntimeInspector: FoundationModelRuntimeInspecting {
+    public init() {}
+
+    public func status(for runtime: FoundationModelRuntime) -> FoundationModelRuntimeStatus {
+        switch runtime {
+        case .onDevice:
+            return onDeviceStatus()
+        case .privateCloudCompute:
+            return privateCloudStatus()
+        }
+    }
+
+    public func quotaUsage(for runtime: FoundationModelRuntime) -> FoundationModelQuotaUsage {
+        switch runtime {
+        case .onDevice:
+            return FoundationModelQuotaUsage(
+                runtime: .onDevice,
+                status: .notApplicable,
+                metadata: metadata(for: .onDevice)
+            )
+        case .privateCloudCompute:
+            return privateCloudQuotaUsage()
+        }
+    }
+
+    private func onDeviceStatus() -> FoundationModelRuntimeStatus {
+        let availability = FoundationModelsModelAvailabilityChecker().currentAvailability()
+        return FoundationModelRuntimeStatus(
+            runtime: .onDevice,
+            isAvailable: availability.isAvailable,
+            reason: availability.reason.map(Self.runtimeReason),
+            metadata: metadata(for: .onDevice)
+        )
+    }
+
+    private func privateCloudStatus() -> FoundationModelRuntimeStatus {
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            let model = PrivateCloudComputeLanguageModel()
+            switch model.availability {
+            case .available:
+                let authorization = PrivateCloudComputeEntitlementChecker().authorization()
+                return FoundationModelRuntimeStatus(
+                    runtime: .privateCloudCompute,
+                    isAvailable: true,
+                    authorization: authorization,
+                    metadata: metadata(for: .privateCloudCompute)
+                )
+            case .unavailable(let reason):
+                return FoundationModelRuntimeStatus(
+                    runtime: .privateCloudCompute,
+                    isAvailable: false,
+                    authorization: PrivateCloudComputeEntitlementChecker().authorization(),
+                    reason: Self.runtimeReason(reason),
+                    metadata: metadata(for: .privateCloudCompute)
+                )
+            }
+        }
+
+        return unsupportedPrivateCloudStatus(reason: .unsupportedOperatingSystem)
+        #else
+        return unsupportedPrivateCloudStatus(reason: .unsupportedToolchain)
+        #endif
+    }
+
+    private func privateCloudQuotaUsage() -> FoundationModelQuotaUsage {
+        let status = privateCloudStatus()
+        if let unavailableResult = privateCloudUnavailableQuotaResult(for: status) {
+            return unavailableResult
+        }
+
+        #if compiler(>=6.4)
+        if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+            return quotaResult(PrivateCloudComputeLanguageModel().quotaUsage)
+        }
+        #endif
+
+        return FoundationModelQuotaUsage(
+            runtime: .privateCloudCompute,
+            status: .unsupported,
+            unavailableReason: .unsupportedToolchain,
+            metadata: metadata(for: .privateCloudCompute)
+        )
+    }
+
+    func privateCloudUnavailableQuotaResult(
+        for status: FoundationModelRuntimeStatus
+    ) -> FoundationModelQuotaUsage? {
+        guard status.runtime == .privateCloudCompute else { return nil }
+        guard status.isSupported else {
+            return FoundationModelQuotaUsage(
+                runtime: .privateCloudCompute,
+                status: .unsupported,
+                unavailableReason: status.reason ?? .unknown,
+                metadata: metadata(for: .privateCloudCompute)
+            )
+        }
+
+        let authorizationReason: FoundationModelRuntimeUnavailableReason
+        switch status.authorization {
+        case .granted:
+            return nil
+        case .missing:
+            authorizationReason = .missingEntitlement
+        case .unknown, .notRequired:
+            authorizationReason = .unknown
+        }
+
+        return FoundationModelQuotaUsage(
+            runtime: .privateCloudCompute,
+            status: .unavailable,
+            unavailableReason: authorizationReason,
+            metadata: metadata(for: .privateCloudCompute)
+        )
+    }
+
+    private func unsupportedPrivateCloudStatus(
+        reason: FoundationModelRuntimeUnavailableReason
+    ) -> FoundationModelRuntimeStatus {
+        FoundationModelRuntimeStatus(
+            runtime: .privateCloudCompute,
+            isSupported: false,
+            isAvailable: false,
+            authorization: .unknown,
+            reason: reason,
+            metadata: metadata(for: .privateCloudCompute)
+        )
+    }
+
+    private func metadata(for runtime: FoundationModelRuntime) -> FoundationModelExecutionMetadata {
+        FoundationModelExecutionMetadata(
+            provider: "Foundation Models",
+            modelIdentifier: runtime == .onDevice ? "system" : "pcc"
+        )
+    }
+
+    private static func runtimeReason(
+        _ reason: FoundationModelAvailabilityUnavailableReason
+    ) -> FoundationModelRuntimeUnavailableReason {
+        switch reason {
+        case .deviceNotEligible:
+            return .deviceNotEligible
+        case .appleIntelligenceNotEnabled:
+            return .appleIntelligenceNotEnabled
+        case .modelNotReady:
+            return .modelNotReady
+        case .unknown:
+            return .unknown
+        }
+    }
+}
+
+#if compiler(>=6.4)
+@available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *)
+private extension FoundationModelsRuntimeInspector {
+    static func runtimeReason(
+        _ reason: PrivateCloudComputeLanguageModel.Availability.UnavailableReason
+    ) -> FoundationModelRuntimeUnavailableReason {
+        switch reason {
+        case .deviceNotEligible:
+            return .deviceNotEligible
+        case .systemNotReady:
+            return .systemNotReady
+        @unknown default:
+            return .unknown
+        }
+    }
+
+    func quotaResult(
+        _ usage: PrivateCloudComputeLanguageModel.QuotaUsage
+    ) -> FoundationModelQuotaUsage {
+        let status: FoundationModelQuotaStatus
+        switch usage.status {
+        case .belowLimit(let details):
+            status = details.isApproachingLimit ? .approachingLimit : .belowLimit
+        case .limitReached:
+            status = .limitReached
+        @unknown default:
+            status = .unavailable
+        }
+
+        return FoundationModelQuotaUsage(
+            runtime: .privateCloudCompute,
+            status: status,
+            resetDate: usage.resetDate,
+            canRequestLimitIncrease: usage.limitIncreaseSuggestion != nil,
+            metadata: metadata(for: .privateCloudCompute)
+        )
+    }
+}
+#endif

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelsStreamingTextGenerator.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelsStreamingTextGenerator.swift
@@ -1,0 +1,60 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelsStreamingTextGenerator: StreamingFoundationModelTextGenerating {
+    public init() {}
+
+    public func streamText(
+        for request: FoundationModelStreamingTextGenerationRequest,
+        onPartialResponse: @escaping @Sendable (String) async -> Void
+    ) async throws -> FoundationModelTextGenerationResult {
+        let prompt = request.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw FoundationModelsKitError.invalidRequest("Missing prompt")
+        }
+
+        let model = try FoundationModelsModelFactory.makeModel(
+            useCase: request.modelUseCase,
+            guardrails: request.guardrails ?? .default,
+            adapterURL: request.adapterURL
+        )
+        let session: LanguageModelSession
+
+        if let systemPrompt = request.systemPrompt?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !systemPrompt.isEmpty {
+            session = LanguageModelSession(
+                model: model,
+                instructions: Instructions(systemPrompt)
+            )
+        } else {
+            session = LanguageModelSession(model: model)
+        }
+
+        var finalContent = ""
+        if let generationOptions = request.generationOptions {
+            for try await partialResponse in session.streamResponse(
+                to: Prompt(prompt),
+                options: generationOptions.foundationModelsValue
+            ) {
+                finalContent = partialResponse.content
+                await onPartialResponse(partialResponse.content)
+            }
+        } else {
+            for try await partialResponse in session.streamResponse(to: Prompt(prompt)) {
+                finalContent = partialResponse.content
+                await onPartialResponse(partialResponse.content)
+            }
+        }
+
+        let tokenCount = await session.transcript.tokenCount(using: model)
+
+        return FoundationModelTextGenerationResult(
+            content: finalContent,
+            metadata: FoundationModelExecutionMetadata(
+                provider: "Foundation Models",
+                modelIdentifier: request.adapterURL?.lastPathComponent ?? request.modelUseCase.rawValue,
+                tokenCount: tokenCount
+            )
+        )
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelsStructuredGenerator.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelsStructuredGenerator.swift
@@ -1,0 +1,60 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelsStructuredGenerator: FoundationModelStructuredGenerating {
+    public init() {}
+
+    public func generate<Output: Generable & Sendable>(
+        _ type: Output.Type,
+        for request: FoundationModelStructuredGenerationRequest<Output>
+    ) async throws -> FoundationModelStructuredGenerationResult<Output> {
+        let prompt = request.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw FoundationModelsKitError.invalidRequest("Missing prompt")
+        }
+
+        let model = try FoundationModelsModelFactory.makeModel(
+            useCase: request.modelUseCase,
+            guardrails: request.guardrails ?? .default,
+            adapterURL: request.adapterURL
+        )
+        let session: LanguageModelSession
+
+        if let systemPrompt = request.systemPrompt?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !systemPrompt.isEmpty {
+            session = LanguageModelSession(
+                model: model,
+                instructions: Instructions(systemPrompt)
+            )
+        } else {
+            session = LanguageModelSession(model: model)
+        }
+
+        let response: LanguageModelSession.Response<Output>
+        if let generationOptions = request.generationOptions {
+            response = try await session.respond(
+                to: Prompt(prompt),
+                generating: type,
+                includeSchemaInPrompt: request.includeSchemaInPrompt,
+                options: generationOptions.foundationModelsValue
+            )
+        } else {
+            response = try await session.respond(
+                to: Prompt(prompt),
+                generating: type,
+                includeSchemaInPrompt: request.includeSchemaInPrompt
+            )
+        }
+
+        let tokenCount = await session.transcript.tokenCount(using: model)
+
+        return FoundationModelStructuredGenerationResult(
+            output: response.content,
+            metadata: FoundationModelExecutionMetadata(
+                provider: "Foundation Models",
+                modelIdentifier: request.adapterURL?.lastPathComponent ?? request.modelUseCase.rawValue,
+                tokenCount: tokenCount
+            )
+        )
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelsSupportedLanguageLister.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelsSupportedLanguageLister.swift
@@ -1,0 +1,35 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelsSupportedLanguageLister: FoundationModelSupportedLanguageListing {
+    public init() {}
+
+    public func supportedLanguages(locale: Locale = .current) -> FoundationModelSupportedLanguages {
+        supportedLanguages(useCase: .general, locale: locale)
+    }
+
+    public func supportedLanguages(
+        useCase: FoundationModelUseCase = .general,
+        locale: Locale = .current
+    ) -> FoundationModelSupportedLanguages {
+        let model = SystemLanguageModel(
+            useCase: useCase.foundationModelsValue,
+            guardrails: FoundationModelGuardrails.default.foundationModelsValue
+        )
+        let languages = model.supportedLanguages.map { language in
+            FoundationModelSupportedLanguage(
+                identifier: language.maximalIdentifier,
+                languageCode: language.languageCode?.identifier ?? "",
+                regionCode: language.region?.identifier
+            )
+        }
+
+        return FoundationModelSupportedLanguages(
+            languages: languages,
+            metadata: FoundationModelExecutionMetadata(
+                provider: "Foundation Models",
+                modelIdentifier: useCase.rawValue
+            )
+        )
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelsTextGenerator.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelsTextGenerator.swift
@@ -1,0 +1,51 @@
+import Foundation
+import FoundationModels
+
+public struct FoundationModelsTextGenerator: FoundationModelTextGenerating {
+    public init() {}
+
+    public func generateText(for request: FoundationModelTextGenerationRequest) async throws -> FoundationModelTextGenerationResult {
+        let prompt = request.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw FoundationModelsKitError.invalidRequest("Missing prompt")
+        }
+
+        let model = try FoundationModelsModelFactory.makeModel(
+            useCase: request.modelUseCase,
+            guardrails: request.guardrails ?? .default,
+            adapterURL: request.adapterURL
+        )
+        let session: LanguageModelSession
+
+        if let systemPrompt = request.systemPrompt?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !systemPrompt.isEmpty {
+            session = LanguageModelSession(
+                model: model,
+                instructions: Instructions(systemPrompt)
+            )
+        } else {
+            session = LanguageModelSession(model: model)
+        }
+
+        let responseContent: String
+        if let generationOptions = request.generationOptions {
+            responseContent = try await session.respond(
+                to: Prompt(prompt),
+                options: generationOptions.foundationModelsValue
+            ).content
+        } else {
+            responseContent = try await session.respond(to: Prompt(prompt)).content
+        }
+
+        let tokenCount = await session.transcript.tokenCount(using: model)
+
+        return FoundationModelTextGenerationResult(
+            content: responseContent,
+            metadata: FoundationModelExecutionMetadata(
+                provider: "Foundation Models",
+                modelIdentifier: request.adapterURL?.lastPathComponent ?? request.modelUseCase.rawValue,
+                tokenCount: tokenCount
+            )
+        )
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/PrivateCloudComputeEntitlementChecker.swift
+++ b/Sources/FoundationModelsKit/Runtime/PrivateCloudComputeEntitlementChecker.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+#if os(macOS)
+import Security
+#endif
+
+public struct PrivateCloudComputeEntitlementChecker: Sendable {
+    public static let entitlement = "com.apple.developer.private-cloud-compute"
+
+    public init() {}
+
+    public func authorization() -> FoundationModelRuntimeAuthorization {
+        #if os(macOS)
+        guard let task = SecTaskCreateFromSelf(nil) else {
+            return .unknown
+        }
+        let value = SecTaskCopyValueForEntitlement(
+            task,
+            Self.entitlement as CFString,
+            nil
+        )
+        return (value as? Bool) == true ? .granted : .missing
+        #else
+        return .unknown
+        #endif
+    }
+}

--- a/Sources/FoundationModelsKit/Support/Task+Cancellation.swift
+++ b/Sources/FoundationModelsKit/Support/Task+Cancellation.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+extension Task where Failure == Error {
+    func valuePropagatingCancellation() async throws -> Success {
+        try await withTaskCancellationHandler {
+            try await value
+        } onCancel: {
+            cancel()
+        }
+    }
+}

--- a/Tests/FoundationModelsKitTests/FoundationModelConversationContextBuilderTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelConversationContextBuilderTests.swift
@@ -1,0 +1,39 @@
+import FoundationModels
+import Testing
+@testable import FoundationModelsKit
+
+@Suite("Foundation Model Conversation Context Builder Tests")
+struct FoundationModelConversationContextBuilderTests {
+  @Test("Conversation text includes tool calls and outputs")
+  func conversationTextIncludesToolCallsAndOutputs() {
+    let transcript = Transcript(entries: [
+      .prompt(.foundationModelsKitTest("What is the weather?")),
+      .toolCalls(Transcript.ToolCalls(id: "weather-call", [])),
+      .toolOutput(
+        Transcript.ToolOutput(
+          id: "weather-output",
+          toolName: "weather",
+          segments: [.text(Transcript.TextSegment(content: "Sunny and 72 degrees"))]
+        )
+      ),
+      .response(.init(assetIDs: [], segments: [.text(.init(content: "It is sunny."))]))
+    ])
+
+    let text = FoundationModelConversationContextBuilder.conversationText(
+      from: transcript,
+      userLabel: "User:",
+      assistantLabel: "Assistant:"
+    )
+
+    #expect(text.contains("User: What is the weather?"))
+    #expect(text.contains("Tool Call: weather-call"))
+    #expect(text.contains("Tool Output (weather): Sunny and 72 degrees"))
+    #expect(text.contains("Assistant: It is sunny."))
+  }
+}
+
+private extension Transcript.Prompt {
+  static func foundationModelsKitTest(_ text: String) -> Self {
+    Self(segments: [.text(Transcript.TextSegment(content: text))])
+  }
+}

--- a/Tests/FoundationModelsKitTests/FoundationModelConversationTokenAccountingTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelConversationTokenAccountingTests.swift
@@ -1,0 +1,28 @@
+import Testing
+@testable import FoundationModelsKit
+
+@Test("A recreated session publishes context usage until generation completes")
+func recreatedSessionPublishesContextUsage() {
+  let contextUsage = ModelTokenUsage(
+    inputTokenCount: 42,
+    measurement: .tokenized,
+    scope: .context
+  )
+  let emptyObservedUsage = ModelTokenUsage(
+    input: .init(totalTokenCount: 0),
+    output: .init(totalTokenCount: 0),
+    measurement: .observed,
+    scope: .session
+  )
+
+  let snapshot = foundationModelConversationTokenSnapshot(
+    contextUsage: contextUsage,
+    observedSessionUsage: emptyObservedUsage,
+    usageSource: .context
+  )
+
+  #expect(snapshot.legacyTokenCount == 42)
+  #expect(snapshot.usage == contextUsage)
+  #expect(snapshot.usage.measurement == .tokenized)
+  #expect(snapshot.usage.scope == .context)
+}

--- a/Tests/FoundationModelsKitTests/FoundationModelConversationTokenAccountingTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelConversationTokenAccountingTests.swift
@@ -26,3 +26,53 @@ func recreatedSessionPublishesContextUsage() {
   #expect(snapshot.usage.measurement == .tokenized)
   #expect(snapshot.usage.scope == .context)
 }
+
+@Test("Accumulated usage falls back to context when observed session usage is empty")
+func accumulatedUsageFallsBackToContextWhenObservedSessionUsageIsEmpty() {
+  let contextUsage = ModelTokenUsage(
+    inputTokenCount: 42,
+    measurement: .tokenized,
+    scope: .context
+  )
+  let emptyObservedUsage = ModelTokenUsage(
+    input: .init(totalTokenCount: 0),
+    output: .init(totalTokenCount: 0),
+    measurement: .observed,
+    scope: .session
+  )
+
+  let snapshot = foundationModelConversationTokenSnapshot(
+    contextUsage: contextUsage,
+    observedSessionUsage: emptyObservedUsage,
+    usageSource: .accumulatedSession
+  )
+
+  #expect(snapshot.legacyTokenCount == 42)
+  #expect(snapshot.usage == contextUsage)
+  #expect(snapshot.usage.scope == .context)
+}
+
+@Test("Accumulated usage prefers non-empty observed session usage")
+func accumulatedUsagePrefersNonEmptyObservedSessionUsage() {
+  let contextUsage = ModelTokenUsage(
+    inputTokenCount: 42,
+    measurement: .tokenized,
+    scope: .context
+  )
+  let observedUsage = ModelTokenUsage(
+    input: .init(totalTokenCount: 5),
+    output: .init(totalTokenCount: 7),
+    measurement: .observed,
+    scope: .session
+  )
+
+  let snapshot = foundationModelConversationTokenSnapshot(
+    contextUsage: contextUsage,
+    observedSessionUsage: observedUsage,
+    usageSource: .accumulatedSession
+  )
+
+  #expect(snapshot.legacyTokenCount == 42)
+  #expect(snapshot.usage == observedUsage)
+  #expect(snapshot.usage.scope == .session)
+}

--- a/Tests/FoundationModelsKitTests/FoundationModelRuntimeInspectionTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelRuntimeInspectionTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Testing
+@testable import FoundationModelsKit
+
+@Test("Runtime inspection preserves requested ordering")
+func runtimeInspectionPreservesOrdering() {
+    let useCase = FoundationModelRuntimeInspectionUseCase(inspector: StubRuntimeInspector())
+
+    let results = useCase.execute(runtimes: [.privateCloudCompute, .onDevice])
+
+    #expect(results.map(\.runtime) == [.privateCloudCompute, .onDevice])
+    #expect(results.map(\.isRunnableInCurrentProcess) == [false, true])
+}
+
+@Test("Quota inspection reports system quota as not applicable")
+func quotaInspectionReportsSystemAsNotApplicable() {
+    let useCase = FoundationModelQuotaUsageInspectionUseCase(inspector: StubRuntimeInspector())
+
+    let results = useCase.execute(runtimes: [.onDevice, .privateCloudCompute])
+
+    #expect(results.map(\.status) == [.notApplicable, .approachingLimit])
+}
+
+@Test(
+    "Unconfirmed managed entitlement makes PCC non-runnable",
+    arguments: [
+        (FoundationModelRuntimeAuthorization.missing, FoundationModelRuntimeUnavailableReason.missingEntitlement),
+        (.unknown, .unknown),
+        (.notRequired, .unknown)
+    ]
+)
+func unconfirmedEntitlementMakesPCCNonRunnable(
+    authorization: FoundationModelRuntimeAuthorization,
+    expectedReason: FoundationModelRuntimeUnavailableReason
+) {
+    let result = FoundationModelRuntimeStatus(
+        runtime: .privateCloudCompute,
+        isAvailable: true,
+        authorization: authorization
+    )
+
+    #expect(result.isSupported)
+    #expect(!result.isRunnableInCurrentProcess)
+    #expect(result.authorization == authorization)
+    #expect(result.reason == expectedReason)
+}
+
+@Test(
+    "Skipped PCC quota preserves the authorization failure reason",
+    arguments: [
+        (FoundationModelRuntimeAuthorization.missing, FoundationModelRuntimeUnavailableReason.missingEntitlement),
+        (.unknown, .unknown)
+    ]
+)
+func skippedPCCQuotaPreservesAuthorizationReason(
+    authorization: FoundationModelRuntimeAuthorization,
+    expectedReason: FoundationModelRuntimeUnavailableReason
+) throws {
+    let runtimeStatus = FoundationModelRuntimeStatus(
+        runtime: .privateCloudCompute,
+        isAvailable: false,
+        authorization: authorization,
+        reason: .systemNotReady
+    )
+
+    let result = try #require(
+        FoundationModelsRuntimeInspector().privateCloudUnavailableQuotaResult(for: runtimeStatus)
+    )
+
+    #expect(result.status == .unavailable)
+    #expect(result.unavailableReason == expectedReason)
+}
+
+@Test("PCC quota remains inspectable while authorized inference is unavailable")
+func authorizedPCCQuotaIgnoresInferenceAvailability() {
+    let runtimeStatus = FoundationModelRuntimeStatus(
+        runtime: .privateCloudCompute,
+        isAvailable: false,
+        authorization: .granted,
+        reason: .systemNotReady
+    )
+
+    let result = FoundationModelsRuntimeInspector()
+        .privateCloudUnavailableQuotaResult(for: runtimeStatus)
+
+    #expect(result == nil)
+}
+
+@Test("PCC quota preserves unsupported runtime reasons")
+func unsupportedPCCQuotaPreservesRuntimeReason() throws {
+    let runtimeStatus = FoundationModelRuntimeStatus(
+        runtime: .privateCloudCompute,
+        isSupported: false,
+        isAvailable: false,
+        authorization: .unknown,
+        reason: .unsupportedOperatingSystem
+    )
+
+    let result = try #require(
+        FoundationModelsRuntimeInspector().privateCloudUnavailableQuotaResult(for: runtimeStatus)
+    )
+
+    #expect(result.status == .unsupported)
+    #expect(result.unavailableReason == .unsupportedOperatingSystem)
+}
+
+@Test("Confirmed managed entitlement makes available PCC runnable")
+func grantedEntitlementMakesPCCRunnable() {
+    let result = FoundationModelRuntimeStatus(
+        runtime: .privateCloudCompute,
+        isAvailable: true,
+        authorization: .granted
+    )
+
+    #expect(result.isRunnableInCurrentProcess)
+}
+
+@Test("On-device runtime is runnable without managed PCC authorization")
+func onDeviceRuntimeDoesNotRequirePCCAuthorization() {
+    let result = FoundationModelRuntimeStatus(
+        runtime: .onDevice,
+        isAvailable: true
+    )
+
+    #expect(result.isRunnableInCurrentProcess)
+    #expect(result.authorization == .notRequired)
+}
+
+@Test("Unsupported or unavailable runtimes remain non-runnable")
+func unsupportedOrUnavailableRuntimesRemainNonRunnable() {
+    let unavailable = FoundationModelRuntimeStatus(
+        runtime: .privateCloudCompute,
+        isAvailable: false,
+        authorization: .granted
+    )
+    let unsupported = FoundationModelRuntimeStatus(
+        runtime: .privateCloudCompute,
+        isSupported: false,
+        isAvailable: true,
+        authorization: .granted
+    )
+
+    #expect(!unavailable.isRunnableInCurrentProcess)
+    #expect(!unsupported.isRunnableInCurrentProcess)
+}
+
+private struct StubRuntimeInspector: FoundationModelRuntimeInspecting {
+    func status(for runtime: FoundationModelRuntime) -> FoundationModelRuntimeStatus {
+        switch runtime {
+        case .onDevice:
+            return FoundationModelRuntimeStatus(runtime: runtime, isAvailable: true)
+        case .privateCloudCompute:
+            return FoundationModelRuntimeStatus(
+                runtime: runtime,
+                isAvailable: true,
+                authorization: .missing,
+                reason: .missingEntitlement
+            )
+        }
+    }
+
+    func quotaUsage(for runtime: FoundationModelRuntime) -> FoundationModelQuotaUsage {
+        switch runtime {
+        case .onDevice:
+            return FoundationModelQuotaUsage(runtime: runtime, status: .notApplicable)
+        case .privateCloudCompute:
+            return FoundationModelQuotaUsage(runtime: runtime, status: .approachingLimit)
+        }
+    }
+}

--- a/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
@@ -62,6 +62,10 @@ struct FoundationModelRuntimeTests {
     #expect(engine.modelRuntime == .onDevice)
     #expect(engine.reasoningLevel == .none)
     #expect(engine.guardrails == .default)
+
+    engine.setReasoningLevel(.deep)
+
+    #expect(engine.reasoningLevel == .none)
   }
 
   @Test("Clear preserves recovered summary context")

--- a/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
@@ -141,4 +141,72 @@ struct FoundationModelRuntimeTests {
 
     #expect(engine.effectiveTargetWindowSize == 1)
   }
+
+  @Test("Sliding window transcript preserves recovered instructions")
+  @MainActor
+  func slidingWindowTranscriptPreservesRecoveredInstructions() {
+    let engine = FoundationModelConversationEngine(
+      configuration: FoundationModelConversationConfiguration(
+        baseInstructions: "Answer from the original system prompt.",
+        summaryInstructions: "Summarize.",
+        summaryPromptPreamble: "Summary:",
+        conversationUserLabel: "User:",
+        conversationAssistantLabel: "Assistant:",
+        continuationNote: "Continue from the summary."
+      )
+    )
+    let summary = FoundationModelConversationSummary(
+      summary: "The user is extracting reusable runtime APIs.",
+      keyTopics: ["runtime extraction"],
+      userPreferences: ["Keep FoundationModelsKit as one package."]
+    )
+
+    engine.applyRecoveredConversationSummary(summary)
+
+    let transcript = engine.slidingWindowTranscript(from: [
+      .instructions(.foundationModelsKitTest("Stale instructions")),
+      .prompt(.foundationModelsKitTest("Latest prompt"))
+    ])
+    let entries = Array(transcript)
+
+    guard case .instructions(let instructions) = entries.first else {
+      Issue.record("Expected sliding window transcript to start with instructions")
+      return
+    }
+
+    #expect(instructions.foundationModelsKitTestText.contains("Answer from the original system prompt."))
+    #expect(instructions.foundationModelsKitTestText.contains("The user is extracting reusable runtime APIs."))
+    #expect(instructions.foundationModelsKitTestText.contains("Stale instructions") == false)
+    #expect(entries.count == 2)
+  }
+}
+
+private extension Transcript.Instructions {
+  static func foundationModelsKitTest(_ text: String) -> Self {
+    Self(
+      segments: [.text(Transcript.TextSegment(content: text))],
+      toolDefinitions: []
+    )
+  }
+
+  var foundationModelsKitTestText: String {
+    segments.foundationModelsKitTestText
+  }
+}
+
+private extension Transcript.Prompt {
+  static func foundationModelsKitTest(_ text: String) -> Self {
+    Self(segments: [.text(Transcript.TextSegment(content: text))])
+  }
+}
+
+private extension [Transcript.Segment] {
+  var foundationModelsKitTestText: String {
+    compactMap { segment in
+      if case .text(let text) = segment {
+        return text.content
+      }
+      return nil
+    }.joined()
+  }
 }

--- a/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
@@ -26,6 +26,26 @@ struct FoundationModelRuntimeTests {
     #expect(granted.reason == nil)
   }
 
+  @Test("Decoded private cloud status recomputes runnable authorization")
+  func decodedPrivateCloudStatusRecomputesRunnableAuthorization() throws {
+    let data = Data("""
+    {
+      "runtime": "privateCloudCompute",
+      "isSupported": true,
+      "isAvailable": true,
+      "isRunnableInCurrentProcess": true,
+      "authorization": "missing",
+      "reason": null,
+      "metadata": {}
+    }
+    """.utf8)
+
+    let status = try JSONDecoder().decode(FoundationModelRuntimeStatus.self, from: data)
+
+    #expect(status.isRunnableInCurrentProcess == false)
+    #expect(status.reason == .missingEntitlement)
+  }
+
   @Test("Supported language display names include region when present")
   func supportedLanguageDisplayNameIncludesRegion() {
     let language = FoundationModelSupportedLanguage(

--- a/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
@@ -179,6 +179,37 @@ struct FoundationModelRuntimeTests {
     #expect(instructions.foundationModelsKitTestText.contains("Stale instructions") == false)
     #expect(entries.count == 2)
   }
+
+  @Test("Sliding window budgets current instructions before trimming history")
+  @MainActor
+  func slidingWindowBudgetsCurrentInstructionsBeforeTrimmingHistory() async {
+    let engine = FoundationModelConversationEngine(
+      configuration: FoundationModelConversationConfiguration(
+        baseInstructions: String(repeating: "system ", count: 200),
+        summaryInstructions: "Summarize.",
+        summaryPromptPreamble: "Summary:",
+        conversationUserLabel: "User:",
+        conversationAssistantLabel: "Assistant:",
+        continuationNote: "Continue.",
+        enableSlidingWindow: true
+      )
+    )
+    engine.setMaxContextSize(120)
+
+    let entries = await engine.slidingWindowEntries(
+      from: Transcript(entries: [
+        .prompt(.foundationModelsKitTest("Latest prompt should not fit."))
+      ])
+    )
+
+    guard case .instructions(let instructions) = entries.first else {
+      Issue.record("Expected budgeted entries to preserve current instructions")
+      return
+    }
+
+    #expect(instructions.foundationModelsKitTestText.contains("system system"))
+    #expect(entries.count == 1)
+  }
 }
 
 private extension Transcript.Instructions {

--- a/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import FoundationModels
+import Testing
+@testable import FoundationModelsKit
+
+@Suite("Foundation Model Runtime Tests")
+struct FoundationModelRuntimeTests {
+  @Test("Private Cloud status requires explicit authorization")
+  func privateCloudStatusRequiresAuthorization() {
+    let missing = FoundationModelRuntimeStatus(
+      runtime: .privateCloudCompute,
+      isAvailable: true,
+      authorization: .missing
+    )
+
+    #expect(missing.isRunnableInCurrentProcess == false)
+    #expect(missing.reason == .missingEntitlement)
+
+    let granted = FoundationModelRuntimeStatus(
+      runtime: .privateCloudCompute,
+      isAvailable: true,
+      authorization: .granted
+    )
+
+    #expect(granted.isRunnableInCurrentProcess == true)
+    #expect(granted.reason == nil)
+  }
+
+  @Test("Supported language display names include region when present")
+  func supportedLanguageDisplayNameIncludesRegion() {
+    let language = FoundationModelSupportedLanguage(
+      identifier: "en-US",
+      languageCode: "en",
+      regionCode: "US"
+    )
+
+    #expect(language.displayName(in: Locale(identifier: "en_US")) == "English (en-US)")
+  }
+
+  @Test("Adapter conversation engines keep adapter-safe defaults when rebuilding")
+  @MainActor
+  func adapterConversationEngineKeepsDefaultGuardrailsWhenRebuilding() {
+    let engine = FoundationModelConversationEngine(
+      configuration: FoundationModelConversationConfiguration(
+        baseInstructions: "Answer briefly.",
+        summaryInstructions: "Summarize.",
+        summaryPromptPreamble: "Summary:",
+        conversationUserLabel: "User:",
+        conversationAssistantLabel: "Assistant:",
+        continuationNote: "Continue."
+      ),
+      model: .default,
+      adapterURL: URL(fileURLWithPath: "/tmp/Test.fmadapter")
+    )
+
+    engine.rebuild(
+      modelRuntime: .privateCloudCompute,
+      reasoningLevel: .deep,
+      guardrails: .permissiveContentTransformations
+    )
+
+    #expect(engine.modelRuntime == .onDevice)
+    #expect(engine.reasoningLevel == .none)
+    #expect(engine.guardrails == .default)
+  }
+}

--- a/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
@@ -260,6 +260,80 @@ struct FoundationModelRuntimeTests {
     #expect(instructions.foundationModelsKitTestText.contains("system system"))
     #expect(entries.count == 1)
   }
+
+  @Test("Overflow one-shot retry remains cancellable")
+  @MainActor
+  func overflowOneShotRetryRemainsCancellable() async {
+    let engine = FoundationModelConversationEngine(
+      configuration: FoundationModelConversationConfiguration(
+        baseInstructions: "Answer briefly.",
+        summaryInstructions: "Summarize.",
+        summaryPromptPreamble: "Summary:",
+        conversationUserLabel: "User:",
+        conversationAssistantLabel: "Assistant:",
+        continuationNote: "Continue."
+      )
+    )
+    let retryProbe = RetryProbe()
+    var responseCallCount = 0
+
+    engine.conversationSummaryOverride = {
+      FoundationModelConversationSummary(
+        summary: "The user asked a question before the context overflow.",
+        keyTopics: ["context recovery"],
+        userPreferences: []
+      )
+    }
+    engine.responseOverride = { _, _ in
+      responseCallCount += 1
+      if responseCallCount == 1 {
+        throw LanguageModelSession.GenerationError.exceededContextWindowSize(
+          .init(debugDescription: "Test context overflow")
+        )
+      }
+
+      await retryProbe.markStarted()
+      try await Task.sleep(for: .seconds(30))
+      return "Late response"
+    }
+
+    let responseTask = Task { @MainActor in
+      try await engine.sendMessage("Retry after recovery")
+    }
+
+    await retryProbe.waitUntilStarted()
+    engine.cancelActiveResponse()
+
+    do {
+      _ = try await responseTask.value
+      Issue.record("Expected overflow retry cancellation to throw")
+    } catch is CancellationError {
+      #expect(responseCallCount == 2)
+    } catch {
+      Issue.record("Expected CancellationError, received \(error)")
+    }
+  }
+}
+
+private actor RetryProbe {
+  private var continuation: CheckedContinuation<Void, Never>?
+  private var started = false
+
+  func waitUntilStarted() async {
+    if started {
+      return
+    }
+
+    await withCheckedContinuation { continuation in
+      self.continuation = continuation
+    }
+  }
+
+  func markStarted() {
+    started = true
+    continuation?.resume()
+    continuation = nil
+  }
 }
 
 private extension Transcript.Instructions {

--- a/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
@@ -88,6 +88,32 @@ struct FoundationModelRuntimeTests {
     #expect(engine.reasoningLevel == .none)
   }
 
+  @Test("Conversation engine reports resolved runtime")
+  @MainActor
+  func conversationEngineReportsResolvedRuntime() {
+    let engine = FoundationModelConversationEngine(
+      configuration: FoundationModelConversationConfiguration(
+        baseInstructions: "Answer briefly.",
+        summaryInstructions: "Summarize.",
+        summaryPromptPreamble: "Summary:",
+        conversationUserLabel: "User:",
+        conversationAssistantLabel: "Assistant:",
+        continuationNote: "Continue.",
+        modelRuntime: .privateCloudCompute
+      )
+    )
+
+    #if compiler(>=6.4)
+    if #available(iOS 27.0, macOS 27.0, visionOS 27.0, watchOS 27.0, *) {
+      #expect(engine.modelRuntime == .privateCloudCompute)
+    } else {
+      #expect(engine.modelRuntime == .onDevice)
+    }
+    #else
+    #expect(engine.modelRuntime == .onDevice)
+    #endif
+  }
+
   @Test("Clear preserves recovered summary context")
   @MainActor
   func clearPreservesRecoveredSummaryContext() {

--- a/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelRuntimeTests.swift
@@ -63,4 +63,82 @@ struct FoundationModelRuntimeTests {
     #expect(engine.reasoningLevel == .none)
     #expect(engine.guardrails == .default)
   }
+
+  @Test("Clear preserves recovered summary context")
+  @MainActor
+  func clearPreservesRecoveredSummaryContext() {
+    let engine = FoundationModelConversationEngine(
+      configuration: FoundationModelConversationConfiguration(
+        baseInstructions: "Answer from the original system prompt.",
+        summaryInstructions: "Summarize.",
+        summaryPromptPreamble: "Summary:",
+        conversationUserLabel: "User:",
+        conversationAssistantLabel: "Assistant:",
+        continuationNote: "Continue from the summary."
+      )
+    )
+    let summary = FoundationModelConversationSummary(
+      summary: "The user is extracting reusable runtime APIs.",
+      keyTopics: ["runtime extraction"],
+      userPreferences: ["Keep FoundationModelsKit as one package."]
+    )
+
+    engine.applyRecoveredConversationSummary(summary)
+    let recoveredInstructions = engine.currentSessionInstructions
+
+    #expect(recoveredInstructions.contains("Answer from the original system prompt."))
+    #expect(recoveredInstructions.contains("The user is extracting reusable runtime APIs."))
+
+    engine.clear()
+
+    #expect(engine.currentSessionInstructions == recoveredInstructions)
+
+    engine.rebuild(baseInstructions: "Use the new explicit baseline.")
+
+    #expect(engine.currentSessionInstructions == "Use the new explicit baseline.")
+  }
+
+  @Test("Sliding window budget does not exceed active context size")
+  @MainActor
+  func slidingWindowBudgetDoesNotExceedActiveContextSize() {
+    let engine = FoundationModelConversationEngine(
+      configuration: FoundationModelConversationConfiguration(
+        baseInstructions: "Answer briefly.",
+        summaryInstructions: "Summarize.",
+        summaryPromptPreamble: "Summary:",
+        conversationUserLabel: "User:",
+        conversationAssistantLabel: "Assistant:",
+        continuationNote: "Continue.",
+        enableSlidingWindow: true,
+        targetWindowSize: 6_000,
+        defaultMaxContextSize: 4_096
+      )
+    )
+
+    #expect(engine.effectiveTargetWindowSize == 4_096)
+
+    engine.setMaxContextSize(1_024)
+
+    #expect(engine.effectiveTargetWindowSize == 1_024)
+  }
+
+  @Test("Sliding window budget keeps a positive lower bound")
+  @MainActor
+  func slidingWindowBudgetKeepsPositiveLowerBound() {
+    let engine = FoundationModelConversationEngine(
+      configuration: FoundationModelConversationConfiguration(
+        baseInstructions: "Answer briefly.",
+        summaryInstructions: "Summarize.",
+        summaryPromptPreamble: "Summary:",
+        conversationUserLabel: "User:",
+        conversationAssistantLabel: "Assistant:",
+        continuationNote: "Continue.",
+        enableSlidingWindow: true,
+        targetWindowSize: 0,
+        defaultMaxContextSize: 4_096
+      )
+    )
+
+    #expect(engine.effectiveTargetWindowSize == 1)
+  }
 }

--- a/Tests/FoundationModelsKitTests/TaskCancellationTests.swift
+++ b/Tests/FoundationModelsKitTests/TaskCancellationTests.swift
@@ -1,0 +1,24 @@
+import Testing
+@testable import FoundationModelsKit
+
+@Test("Caller cancellation propagates to owned task")
+func valuePropagatesCallerCancellationToOwnedTask() async {
+  let ownedTask = Task<Void, Error> {
+    try await Task.sleep(for: .seconds(30))
+  }
+  let caller = Task<Void, Error> {
+    try await ownedTask.valuePropagatingCancellation()
+  }
+
+  await Task.yield()
+  caller.cancel()
+
+  do {
+    try await caller.value
+    Issue.record("Expected caller cancellation to throw")
+  } catch is CancellationError {
+    #expect(ownedTask.isCancelled)
+  } catch {
+    Issue.record("Expected CancellationError, received \(error)")
+  }
+}


### PR DESCRIPTION
## Summary
- Move reusable AFM runtime, request/result, guardrail, token accounting, conversation, and inspection APIs into the existing FoundationModelsKit product
- Keep the public surface as a single `import FoundationModelsKit` while organizing implementation folders under Capabilities, Runtime, Requests, Results, Errors, and Support
- Rename Lab-branded runtime types to generic FoundationModelsKit names suitable for public package consumers
- Port the runtime, token accounting, cancellation, and inspection tests into the Kit test suite

## Validation
- `swift test`

## Follow-up
- The Lab consumer PR points at this branch until this package PR is merged.