### PR TITLE
Add DocC package overviews

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,11 +21,13 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "FoundationModelsKit"
+            name: "FoundationModelsKit",
+            exclude: ["FoundationModelsKit.docc"]
         ),
         .target(
             name: "FoundationModelsTools",
-            dependencies: ["FoundationModelsKit"]
+            dependencies: ["FoundationModelsKit"],
+            exclude: ["FoundationModelsTools.docc"]
         ),
         .testTarget(
             name: "FoundationModelsKitTests",

--- a/Sources/FoundationModelsKit/FoundationModelsKit.docc/FoundationModelsKit.md
+++ b/Sources/FoundationModelsKit/FoundationModelsKit.docc/FoundationModelsKit.md
@@ -1,0 +1,66 @@
+# ``FoundationModelsKit``
+
+Reusable runtime, schema, token, and conversation utilities for Apple's Foundation Models framework.
+
+## Overview
+
+`FoundationModelsKit` provides app- and CLI-ready building blocks around the Foundation Models framework. Use it when you need stable request and result types, runtime inspection, token accounting, schema conversion, or a managed conversation engine on top of `LanguageModelSession`.
+
+The package is designed to keep Foundation Models code reusable outside a single app target:
+
+- **Runtime inspection.** Check on-device and Private Cloud Compute availability, process authorization, and quota state with ``FoundationModelsRuntimeInspector``.
+- **Generation use cases.** Wrap text, streaming text, structured output, and dynamic schema generation in request/result types that are easy to test and log.
+- **Schema utilities.** Decode, validate, and convert a supported JSON Schema subset into Foundation Models `GenerationSchema` values with ``FoundationModelsJSONSchema``.
+- **Token accounting.** Estimate transcript size, inspect model token usage, and trim transcript entries to a target budget.
+- **Conversation engine.** Use ``FoundationModelConversationEngine`` for prompt validation, streaming, cancellation, context-window recovery, and summary-based continuation.
+- **Error projection.** Convert Foundation Models framework errors into stable, machine-readable categories with ``FoundationModelErrorProjection``.
+
+## Topics
+
+### Runtime Inspection
+
+- ``FoundationModelRuntime``
+- ``FoundationModelsRuntimeInspector``
+- ``FoundationModelRuntimeStatus``
+- ``FoundationModelQuotaUsage``
+- ``FoundationModelAvailability``
+- ``FoundationModelSupportedLanguages``
+
+### Generation
+
+- ``FoundationModelTextGenerationUseCase``
+- ``FoundationModelStreamingTextGenerationUseCase``
+- ``FoundationModelStructuredGenerationUseCase``
+- ``FoundationModelDynamicSchemaGenerationUseCase``
+- ``FoundationModelTextGenerationRequest``
+- ``FoundationModelStreamingTextGenerationRequest``
+- ``FoundationModelStructuredGenerationRequest``
+- ``FoundationModelDynamicSchemaGenerationRequest``
+
+### Conversation Runtime
+
+- ``FoundationModelConversationEngine``
+- ``FoundationModelConversationConfiguration``
+- ``FoundationModelConversationSummary``
+- ``FoundationModelGenerationOptions``
+- ``FoundationModelGuardrails``
+- ``FoundationModelReasoningLevel``
+- ``FoundationModelUseCase``
+
+### Schemas
+
+- ``FoundationModelsJSONSchema``
+- ``FoundationModelsJSONSchemaError``
+- ``RuntimeCompatibleGenerable``
+
+### Tokens and Transcripts
+
+- ``ModelTokenUsage``
+- ``estimateTokens(from:)``
+- ``estimateTokensConservative(from:)``
+
+### Errors
+
+- ``FoundationModelErrorProjection``
+- ``FoundationModelsKitError``
+

--- a/Sources/FoundationModelsTools/FoundationModelsTools.docc/FoundationModelsTools.md
+++ b/Sources/FoundationModelsTools/FoundationModelsTools.docc/FoundationModelsTools.md
@@ -1,0 +1,38 @@
+# ``FoundationModelsTools``
+
+Ready-to-use Foundation Models tools for Apple platform capabilities and web services.
+
+## Overview
+
+`FoundationModelsTools` provides concrete `Tool` implementations that can be added to a `LanguageModelSession` or called directly from an app, command-line tool, or test harness. The product re-exports `FoundationModelsKit`, so importing `FoundationModelsTools` also makes the shared runtime and schema utilities available.
+
+The tools preserve platform permission boundaries and surface typed errors instead of silently fabricating data:
+
+- **Weather.** Fetch current weather for a city with ``WeatherTool``.
+- **Web search.** Query Exa-backed search results with ``WebTool``.
+- **Web metadata.** Extract title, description, and image metadata with ``WebMetadataTool``.
+- **Contacts.** Search, read, and create contacts with ``ContactsTool``.
+- **Calendar.** Create, query, read, and update events with ``CalendarTool``.
+- **Reminders.** Create, query, read, update, and complete reminders with ``RemindersTool``.
+- **Location.** Resolve current location, geocode addresses, reverse geocode coordinates, and calculate distances with ``LocationTool``.
+- **Health.** Read authorized HealthKit data with ``HealthTool``.
+- **Music.** Search and control Apple Music playback with ``MusicTool``.
+
+## Topics
+
+### Tools
+
+- ``WeatherTool``
+- ``WebTool``
+- ``WebMetadataTool``
+- ``ContactsTool``
+- ``CalendarTool``
+- ``RemindersTool``
+- ``LocationTool``
+- ``HealthTool``
+- ``MusicTool``
+
+### Web Services
+
+- ``ExaWebService``
+


### PR DESCRIPTION
## Summary
- add DocC overview catalog for FoundationModelsKit
- add DocC overview catalog for FoundationModelsTools
- exclude DocC catalogs from SwiftPM build inputs so normal builds stay warning-free

## Validation
- swift build
- swift test

Note: this SwiftPM installation does not expose the generate-documentation plugin, so local DocC link validation was not available.