### PR TITLE
Secure Exa keys and expose tool query IDs

### DIFF
--- a/Sources/FoundationModelsTools/Support/ExaAPIKeyStore.swift
+++ b/Sources/FoundationModelsTools/Support/ExaAPIKeyStore.swift
@@ -1,0 +1,122 @@
+//
+//  ExaAPIKeyStore.swift
+//  FoundationModelsTools
+import Foundation
+import Security
+
+/// Stores the Exa API key in the system Keychain.
+public struct ExaAPIKeyStore: @unchecked Sendable {
+  public static let shared = ExaAPIKeyStore()
+
+  static let legacyUserDefaultsKey = "exaAPIKey"
+
+  private let service: String
+  private let account: String
+  private let legacyUserDefaults: UserDefaults
+
+  public init(
+    service: String = "com.rryam.FoundationModelsTools.exa",
+    account: String = "apiKey",
+    legacyUserDefaults: UserDefaults = .standard
+  ) {
+    self.service = service
+    self.account = account
+    self.legacyUserDefaults = legacyUserDefaults
+  }
+
+  /// Returns the stored API key, migrating the legacy UserDefaults value if needed.
+  public func apiKey() -> String {
+    if let key = keychainAPIKey(), !key.isEmpty {
+      return key
+    }
+
+    guard
+      let legacyKey = legacyUserDefaults.string(forKey: Self.legacyUserDefaultsKey)?
+        .trimmingCharacters(in: .whitespacesAndNewlines),
+      !legacyKey.isEmpty
+    else {
+      return ""
+    }
+
+    do {
+      try saveAPIKey(legacyKey)
+      legacyUserDefaults.removeObject(forKey: Self.legacyUserDefaultsKey)
+    } catch {
+      return ""
+    }
+
+    return legacyKey
+  }
+
+  /// Saves the API key in Keychain. Passing an empty string deletes the stored key.
+  public func saveAPIKey(_ apiKey: String) throws {
+    let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmedKey.isEmpty else {
+      try deleteAPIKey()
+      return
+    }
+
+    let encodedKey = Data(trimmedKey.utf8)
+    let updateStatus = SecItemUpdate(
+      query as CFDictionary,
+      [kSecValueData: encodedKey] as CFDictionary
+    )
+
+    switch updateStatus {
+    case errSecSuccess:
+      return
+    case errSecItemNotFound:
+      var attributes = query
+      attributes[kSecValueData as String] = encodedKey
+      let addStatus = SecItemAdd(attributes as CFDictionary, nil)
+      guard addStatus == errSecSuccess else {
+        throw ExaAPIKeyStoreError.keychainWriteFailed(addStatus)
+      }
+    default:
+      throw ExaAPIKeyStoreError.keychainWriteFailed(updateStatus)
+    }
+  }
+
+  public func deleteAPIKey() throws {
+    let status = SecItemDelete(query as CFDictionary)
+    guard status == errSecSuccess || status == errSecItemNotFound else {
+      throw ExaAPIKeyStoreError.keychainDeleteFailed(status)
+    }
+  }
+
+  private func keychainAPIKey() -> String? {
+    var lookup = query
+    lookup[kSecReturnData as String] = true
+    lookup[kSecMatchLimit as String] = kSecMatchLimitOne
+
+    var item: CFTypeRef?
+    let status = SecItemCopyMatching(lookup as CFDictionary, &item)
+    guard status == errSecSuccess, let data = item as? Data else {
+      return nil
+    }
+
+    return String(data: data, encoding: .utf8)
+  }
+
+  private var query: [String: Any] {
+    [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: service,
+      kSecAttrAccount as String: account
+    ]
+  }
+}
+
+public enum ExaAPIKeyStoreError: Error, LocalizedError {
+  case keychainWriteFailed(OSStatus)
+  case keychainDeleteFailed(OSStatus)
+
+  public var errorDescription: String? {
+    switch self {
+    case .keychainWriteFailed(let status):
+      return "Unable to save Exa API key to Keychain (status \(status))."
+    case .keychainDeleteFailed(let status):
+      return "Unable to delete Exa API key from Keychain (status \(status))."
+    }
+  }
+}

--- a/Sources/FoundationModelsTools/Support/ExaAPIKeyStore.swift
+++ b/Sources/FoundationModelsTools/Support/ExaAPIKeyStore.swift
@@ -42,7 +42,8 @@ public struct ExaAPIKeyStore: @unchecked Sendable {
       try saveAPIKey(legacyKey)
       legacyUserDefaults.removeObject(forKey: Self.legacyUserDefaultsKey)
     } catch {
-      return ""
+      legacyUserDefaults.removeObject(forKey: Self.legacyUserDefaultsKey)
+      return legacyKey
     }
 
     return legacyKey

--- a/Sources/FoundationModelsTools/Tools/CalendarTool.swift
+++ b/Sources/FoundationModelsTools/Tools/CalendarTool.swift
@@ -216,25 +216,8 @@ public struct CalendarTool: Tool {
 
     let events = eventStore.events(matching: predicate)
 
-    var eventsDescription = ""
-
-    for (index, event) in events.enumerated() {
-      let dateFormatter = DateFormatter()
-      dateFormatter.dateStyle = .medium
-      dateFormatter.timeStyle = .short
-
-      let location = event.location != nil ? " at \(event.location!)" : ""
-      let calendar = event.calendar?.title ?? "Unknown Calendar"
-
-      eventsDescription += "\(index + 1). \(event.title ?? "Untitled")\n"
-      eventsDescription +=
-        "   When: \(dateFormatter.string(from: event.startDate)) - \(dateFormatter.string(from: event.endDate))\n"
-      eventsDescription += "   Calendar: \(calendar)\(location)\n"
-      if let notes = event.notes, !notes.isEmpty {
-        eventsDescription += "   Notes: \(notes.prefix(50))...\n"
-      }
-      eventsDescription += "\n"
-    }
+    let eventSummaries = events.map(CalendarEventSummary.init)
+    var eventsDescription = Self.formatEventQueryResults(eventSummaries)
 
     if eventsDescription.isEmpty {
       eventsDescription = "No events found in the next \(daysToQuery) days"
@@ -244,6 +227,7 @@ public struct CalendarTool: Tool {
       "status": "success",
       "count": events.count,
       "daysQueried": daysToQuery,
+      "eventIds": eventSummaries.map(\.id),
       "events": eventsDescription.trimmingCharacters(in: .whitespacesAndNewlines),
       "message": "Found \(events.count) event(s) in the next \(daysToQuery) days"
     ])
@@ -349,6 +333,70 @@ public struct CalendarTool: Tool {
       "error": error.localizedDescription,
       "message": "Failed to perform calendar operation"
     ])
+  }
+}
+
+struct CalendarEventSummary: Sendable {
+  let id: String
+  let title: String
+  let startDate: Date
+  let endDate: Date
+  let location: String?
+  let calendarTitle: String
+  let notes: String?
+
+  init(
+    id: String,
+    title: String,
+    startDate: Date,
+    endDate: Date,
+    location: String? = nil,
+    calendarTitle: String,
+    notes: String? = nil
+  ) {
+    self.id = id
+    self.title = title
+    self.startDate = startDate
+    self.endDate = endDate
+    self.location = location
+    self.calendarTitle = calendarTitle
+    self.notes = notes
+  }
+
+  init(event: EKEvent) {
+    self.id = event.eventIdentifier ?? ""
+    self.title = event.title ?? "Untitled"
+    self.startDate = event.startDate
+    self.endDate = event.endDate
+    self.location = event.location
+    self.calendarTitle = event.calendar?.title ?? "Unknown Calendar"
+    self.notes = event.notes
+  }
+}
+
+extension CalendarTool {
+  static func formatEventQueryResults(_ events: [CalendarEventSummary]) -> String {
+    var eventsDescription = ""
+
+    for (index, event) in events.enumerated() {
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateStyle = .medium
+      dateFormatter.timeStyle = .short
+
+      let location = event.location != nil ? " at \(event.location!)" : ""
+
+      eventsDescription += "\(index + 1). \(event.title)\n"
+      eventsDescription += "   Event ID: \(event.id)\n"
+      eventsDescription +=
+        "   When: \(dateFormatter.string(from: event.startDate)) - \(dateFormatter.string(from: event.endDate))\n"
+      eventsDescription += "   Calendar: \(event.calendarTitle)\(location)\n"
+      if let notes = event.notes, !notes.isEmpty {
+        eventsDescription += "   Notes: \(notes.prefix(50))...\n"
+      }
+      eventsDescription += "\n"
+    }
+
+    return eventsDescription
   }
 }
 

--- a/Sources/FoundationModelsTools/Tools/ContactsTool.swift
+++ b/Sources/FoundationModelsTools/Tools/ContactsTool.swift
@@ -159,10 +159,13 @@ public struct ContactsTool: Tool {
                     return false
                 }
 
-                return formatContactsOutput(contacts: filteredContacts, query: searchQuery)
+                return formatContactsOutput(
+                    contacts: filteredContacts.map(ContactSearchResult.init),
+                    query: searchQuery
+                )
             }
 
-            return formatContactsOutput(contacts: contacts, query: searchQuery)
+            return formatContactsOutput(contacts: contacts.map(ContactSearchResult.init), query: searchQuery)
         } catch {
             return createErrorOutput(error: error)
         }
@@ -265,17 +268,8 @@ public struct ContactsTool: Tool {
         }
     }
 
-    private func formatContactsOutput(contacts: [CNContact], query: String) -> GeneratedContent {
-        var contactsDescription = ""
-
-        for (index, contact) in contacts.enumerated() {
-            let name = "\(contact.givenName) \(contact.familyName)".trimmingCharacters(in: .whitespaces)
-            let email = contact.emailAddresses.first?.value as String? ?? "No email"
-            let phone = contact.phoneNumbers.first?.value.stringValue ?? "No phone"
-            let org = contact.organizationName.isEmpty ? "" : " (\(contact.organizationName))"
-
-            contactsDescription += "\(index + 1). \(name)\(org) - Email: \(email), Phone: \(phone)\n"
-        }
+    private func formatContactsOutput(contacts: [ContactSearchResult], query: String) -> GeneratedContent {
+        var contactsDescription = Self.formatContactSearchResults(contacts)
 
         if contactsDescription.isEmpty {
             contactsDescription = "No contacts found matching '\(query)'"
@@ -285,6 +279,7 @@ public struct ContactsTool: Tool {
             "status": "success",
             "query": query,
             "count": contacts.count,
+            "contactIds": contacts.map(\.id),
             "results": contactsDescription.trimmingCharacters(in: .whitespacesAndNewlines),
             "message": "Found \(contacts.count) contact(s) matching '\(query)'"
         ])
@@ -296,6 +291,59 @@ public struct ContactsTool: Tool {
             "error": error.localizedDescription,
             "message": "Failed to perform contact operation"
         ])
+    }
+}
+
+struct ContactSearchResult: Sendable {
+    let id: String
+    let givenName: String
+    let familyName: String
+    let email: String?
+    let phone: String?
+    let organization: String?
+
+    init(
+        id: String,
+        givenName: String,
+        familyName: String,
+        email: String? = nil,
+        phone: String? = nil,
+        organization: String? = nil
+    ) {
+        self.id = id
+        self.givenName = givenName
+        self.familyName = familyName
+        self.email = email
+        self.phone = phone
+        self.organization = organization
+    }
+
+    init(contact: CNContact) {
+        self.id = contact.identifier
+        self.givenName = contact.givenName
+        self.familyName = contact.familyName
+        self.email = contact.emailAddresses.first?.value as String?
+        self.phone = contact.phoneNumbers.first?.value.stringValue
+        self.organization = contact.organizationName.isEmpty ? nil : contact.organizationName
+    }
+}
+
+extension ContactsTool {
+    static func formatContactSearchResults(_ contacts: [ContactSearchResult]) -> String {
+        var contactsDescription = ""
+
+        for (index, contact) in contacts.enumerated() {
+            let name = "\(contact.givenName) \(contact.familyName)"
+                .trimmingCharacters(in: .whitespaces)
+            let email = contact.email ?? "No email"
+            let phone = contact.phone ?? "No phone"
+            let org = contact.organization.map { " (\($0))" } ?? ""
+
+            contactsDescription +=
+                "\(index + 1). \(name)\(org) - Contact ID: \(contact.id), Email: \(email), Phone: \(phone)\n"
+        }
+
+        return contactsDescription
     }
 }
 

--- a/Sources/FoundationModelsTools/Tools/RemindersTool.swift
+++ b/Sources/FoundationModelsTools/Tools/RemindersTool.swift
@@ -193,7 +193,7 @@ public struct RemindersTool: Tool {
         "title": reminder.title ?? "",
         "list": reminder.calendar?.title ?? "",
         "dueDate": formatDateComponents(reminder.dueDateComponents),
-        "priority": getPriorityString(reminder.priority)
+        "priority": Self.getPriorityString(reminder.priority)
       ])
     } catch {
       return createErrorOutput(error: error)
@@ -248,26 +248,7 @@ public struct RemindersTool: Tool {
       return false
     }
 
-    var remindersDescription = ""
-
-    for (index, reminder) in reminders.enumerated() {
-      let completed = reminder.isCompleted ? "[x]" : "[ ]"
-      let priority = getPriorityString(reminder.priority)
-      let dueDate = formatReminderDueDate(reminder.dueDate)
-
-      remindersDescription += "\(index + 1). \(completed) \(reminder.title)\n"
-      remindersDescription += "   List: \(reminder.listName)\n"
-      if !dueDate.isEmpty {
-        remindersDescription += "   Due: \(dueDate)\n"
-      }
-      if priority != "None" {
-        remindersDescription += "   Priority: \(priority)\n"
-      }
-      if let notes = reminder.notes, !notes.isEmpty {
-        remindersDescription += "   Notes: \(notes.prefix(50))...\n"
-      }
-      remindersDescription += "\n"
-    }
+    var remindersDescription = Self.formatReminderQueryResults(reminders)
 
     if remindersDescription.isEmpty {
       remindersDescription = "No reminders found with filter '\(filter)'"
@@ -277,6 +258,7 @@ public struct RemindersTool: Tool {
       "status": "success",
       "filter": filter,
       "count": reminders.count,
+      "reminderIds": reminders.map(\.id),
       "reminders": remindersDescription.trimmingCharacters(in: .whitespacesAndNewlines),
       "message": "Found \(reminders.count) reminder(s)"
     ])
@@ -370,7 +352,7 @@ public struct RemindersTool: Tool {
         "title": reminder.title ?? "",
         "list": reminder.calendar?.title ?? "",
         "dueDate": formatDateComponents(reminder.dueDateComponents),
-        "priority": getPriorityString(reminder.priority)
+        "priority": Self.getPriorityString(reminder.priority)
       ])
     } catch {
       return createErrorOutput(error: error)
@@ -448,7 +430,7 @@ public struct RemindersTool: Tool {
     return formatter.string(from: date)
   }
 
-  private func formatReminderDueDate(_ date: Date?) -> String {
+  private static func formatReminderDueDate(_ date: Date?) -> String {
     guard let date else { return "" }
 
     let formatter = DateFormatter()
@@ -457,7 +439,7 @@ public struct RemindersTool: Tool {
     return formatter.string(from: date)
   }
 
-  private func getPriorityString(_ priority: Int) -> String {
+  private static func getPriorityString(_ priority: Int) -> String {
     switch priority {
     case 1...3:
       return "High"
@@ -479,7 +461,8 @@ public struct RemindersTool: Tool {
   }
 }
 
-private struct ReminderSnapshot: Sendable {
+struct ReminderSnapshot: Sendable {
+  let id: String
   let title: String
   let listName: String
   let dueDate: Date?
@@ -488,12 +471,59 @@ private struct ReminderSnapshot: Sendable {
   let isCompleted: Bool
 
   init(reminder: EKReminder) {
+    self.id = reminder.calendarItemIdentifier
     self.title = reminder.title ?? "Untitled"
     self.listName = reminder.calendar?.title ?? "Unknown List"
     self.dueDate = reminder.dueDateComponents?.date
     self.priority = reminder.priority
     self.notes = reminder.notes
     self.isCompleted = reminder.isCompleted
+  }
+
+  init(
+    id: String,
+    title: String,
+    listName: String,
+    dueDate: Date? = nil,
+    priority: Int = 0,
+    notes: String? = nil,
+    isCompleted: Bool = false
+  ) {
+    self.id = id
+    self.title = title
+    self.listName = listName
+    self.dueDate = dueDate
+    self.priority = priority
+    self.notes = notes
+    self.isCompleted = isCompleted
+  }
+}
+
+extension RemindersTool {
+  static func formatReminderQueryResults(_ reminders: [ReminderSnapshot]) -> String {
+    var remindersDescription = ""
+
+    for (index, reminder) in reminders.enumerated() {
+      let completed = reminder.isCompleted ? "[x]" : "[ ]"
+      let priority = Self.getPriorityString(reminder.priority)
+      let dueDate = Self.formatReminderDueDate(reminder.dueDate)
+
+      remindersDescription += "\(index + 1). \(completed) \(reminder.title)\n"
+      remindersDescription += "   Reminder ID: \(reminder.id)\n"
+      remindersDescription += "   List: \(reminder.listName)\n"
+      if !dueDate.isEmpty {
+        remindersDescription += "   Due: \(dueDate)\n"
+      }
+      if priority != "None" {
+        remindersDescription += "   Priority: \(priority)\n"
+      }
+      if let notes = reminder.notes, !notes.isEmpty {
+        remindersDescription += "   Notes: \(notes.prefix(50))...\n"
+      }
+      remindersDescription += "\n"
+    }
+
+    return remindersDescription
   }
 }
 

--- a/Sources/FoundationModelsTools/Tools/WebTool.swift
+++ b/Sources/FoundationModelsTools/Tools/WebTool.swift
@@ -8,7 +8,6 @@
 import Foundation
 import FoundationModels
 import FoundationModelsKit
-import SwiftUI
 
 /// A tool for web search using the Exa API.
 ///
@@ -19,12 +18,13 @@ import SwiftUI
 /// and `auto` (automatically selects the best type).
 ///
 /// ```swift
-/// // Configure the API key using @AppStorage("exaAPIKey")
+/// // Configure the API key using the system Keychain.
+/// try ExaAPIKeyStore.shared.saveAPIKey("exa_...")
 /// let session = LanguageModelSession(tools: [WebTool()])
 /// let response = try await session.respond(to: "Search for the latest ML advancements")
 /// ```
 ///
-/// - Important: Requires an Exa API key stored in `@AppStorage("exaAPIKey")`.
+/// - Important: Requires an Exa API key stored with `ExaAPIKeyStore`.
 ///   Do not store API keys in client-side code for production apps.
 ///   Use a server-side proxy to make Exa API requests securely.
 public struct WebTool: Tool {
@@ -89,12 +89,16 @@ public struct WebTool: Tool {
   }
 
   private let exaService: ExaWebService
-
-  /// AppStorage for the API key
-  @AppStorage("exaAPIKey") private var exaAPIKey: String = ""
+  private let apiKeyStore: ExaAPIKeyStore
 
   public init() {
     self.exaService = ExaWebService()
+    self.apiKeyStore = .shared
+  }
+
+  public init(apiKeyStore: ExaAPIKeyStore) {
+    self.exaService = ExaWebService()
+    self.apiKeyStore = apiKeyStore
   }
 
   public func call(arguments: Arguments) async throws -> some PromptRepresentable {
@@ -104,6 +108,7 @@ public struct WebTool: Tool {
       return createErrorOutput(for: searchQuery, error: WebError.emptyQuery)
     }
 
+    let exaAPIKey = apiKeyStore.apiKey()
     guard !exaAPIKey.isEmpty else {
       return createErrorOutput(for: searchQuery, error: WebError.missingAPIKey)
     }
@@ -114,7 +119,8 @@ public struct WebTool: Tool {
         numResults: arguments.numResults,
         type: arguments.type,
         includeContents: arguments.includeContents,
-        category: arguments.category
+        category: arguments.category,
+        apiKey: exaAPIKey
       )
       return createSuccessOutput(from: searchData)
     } catch {
@@ -127,12 +133,13 @@ public struct WebTool: Tool {
     numResults: Int?,
     type: String?,
     includeContents: Bool?,
-    category: String?
+    category: String?,
+    apiKey: String
   ) async throws -> SearchData {
     do {
       let exaResponse = try await exaService.search(
         query: query,
-        apiKey: exaAPIKey,
+        apiKey: apiKey,
         numResults: numResults,
         type: type,
         includeContents: includeContents,

--- a/Tests/FoundationModelsToolsTests/ToolQueryIdentifierTests.swift
+++ b/Tests/FoundationModelsToolsTests/ToolQueryIdentifierTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import FoundationModelsTools
+
+@Suite("Tool Query Identifier Tests")
+struct ToolQueryIdentifierTests {
+  @Test("Calendar query rows include event IDs")
+  func calendarQueryRowsIncludeEventIDs() {
+    let startDate = Date(timeIntervalSince1970: 1_820_000_000)
+    let event = CalendarEventSummary(
+      id: "event-123",
+      title: "Design Review",
+      startDate: startDate,
+      endDate: startDate.addingTimeInterval(3_600),
+      location: "Studio",
+      calendarTitle: "Work",
+      notes: "Bring the spec"
+    )
+
+    let output = CalendarTool.formatEventQueryResults([event])
+
+    #expect(output.contains("Event ID: event-123"))
+    #expect(output.contains("Design Review"))
+  }
+
+  @Test("Reminder query rows include reminder IDs")
+  func reminderQueryRowsIncludeReminderIDs() {
+    let reminder = ReminderSnapshot(
+      id: "reminder-456",
+      title: "Ship audit fix",
+      listName: "Engineering",
+      priority: 1
+    )
+
+    let output = RemindersTool.formatReminderQueryResults([reminder])
+
+    #expect(output.contains("Reminder ID: reminder-456"))
+    #expect(output.contains("Ship audit fix"))
+  }
+
+  @Test("Contact search rows include contact IDs")
+  func contactSearchRowsIncludeContactIDs() {
+    let contact = ContactSearchResult(
+      id: "contact-789",
+      givenName: "Avery",
+      familyName: "Stone",
+      email: "avery@example.com",
+      phone: "+1 555 0100",
+      organization: "Example Co"
+    )
+
+    let output = ContactsTool.formatContactSearchResults([contact])
+
+    #expect(output.contains("Contact ID: contact-789"))
+    #expect(output.contains("Avery Stone"))
+  }
+}
+
+@Suite("Exa API Key Store Tests")
+struct ExaAPIKeyStoreTests {
+  @Test("API keys are saved outside UserDefaults")
+  func apiKeysAreSavedOutsideUserDefaults() throws {
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    let store = ExaAPIKeyStore(
+      service: "FoundationModelsToolsTests.\(UUID().uuidString)",
+      account: "apiKey",
+      legacyUserDefaults: defaults
+    )
+    defer { try? store.deleteAPIKey() }
+
+    try store.saveAPIKey(" exa-test-key ")
+
+    #expect(store.apiKey() == "exa-test-key")
+    #expect(defaults.string(forKey: ExaAPIKeyStore.legacyUserDefaultsKey) == nil)
+  }
+
+  @Test("Legacy UserDefaults API key migrates to Keychain and is removed")
+  func legacyUserDefaultsAPIKeyMigratesToKeychain() throws {
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    let service = "FoundationModelsToolsTests.\(UUID().uuidString)"
+    let store = ExaAPIKeyStore(
+      service: service,
+      account: "apiKey",
+      legacyUserDefaults: defaults
+    )
+    defer { try? store.deleteAPIKey() }
+
+    defaults.set("legacy-exa-key", forKey: ExaAPIKeyStore.legacyUserDefaultsKey)
+
+    #expect(store.apiKey() == "legacy-exa-key")
+    #expect(defaults.string(forKey: ExaAPIKeyStore.legacyUserDefaultsKey) == nil)
+
+    let reloadedStore = ExaAPIKeyStore(
+      service: service,
+      account: "apiKey",
+      legacyUserDefaults: defaults
+    )
+    #expect(reloadedStore.apiKey() == "legacy-exa-key")
+  }
+}


### PR DESCRIPTION
## Summary
- replace WebTool plaintext @AppStorage API key lookup with a Keychain-backed ExaAPIKeyStore
- migrate the legacy UserDefaults `exaAPIKey` value into Keychain on first lookup and remove the legacy value from UserDefaults
- include Calendar event IDs, Reminder IDs, and Contact IDs in query/search outputs so follow-up read/update/complete/delete actions have the identifiers they require
- add focused tests for ID formatting and Exa API key storage/migration

## Verification
- swift test
- swift build

## Migration note
Existing `UserDefaults.standard["exaAPIKey"]` values are migrated to Keychain by `ExaAPIKeyStore.apiKey()` on first lookup. The legacy UserDefaults value is removed during that lookup; if a Keychain write fails, the legacy key can still satisfy that current lookup in memory but is not kept in UserDefaults. New callers should store Exa keys with `try ExaAPIKeyStore.shared.saveAPIKey(...)`.