### PR TITLE
Require confirmation for Calendar and Reminders mutations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,10 @@ let package = Package(
         .library(
             name: "FoundationModelsTools",
             targets: ["FoundationModelsTools"]
+        ),
+        .library(
+            name: "FoundationModelsToolsTestSupport",
+            targets: ["FoundationModelsToolsTestSupport"]
         )
     ],
     targets: [
@@ -27,13 +31,20 @@ let package = Package(
             name: "FoundationModelsTools",
             dependencies: ["FoundationModelsKit"]
         ),
+        .target(
+            name: "FoundationModelsToolsTestSupport",
+            dependencies: ["FoundationModelsTools"]
+        ),
         .testTarget(
             name: "FoundationModelsKitTests",
             dependencies: ["FoundationModelsKit"]
         ),
         .testTarget(
             name: "FoundationModelsToolsTests",
-            dependencies: ["FoundationModelsTools"]
+            dependencies: [
+                "FoundationModelsTools",
+                "FoundationModelsToolsTestSupport"
+            ]
         )
     ]
 )

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ It is designed to complement Apple's Foundation Models framework and Apple's Fou
 
 ## Products
 
-The package exposes two products:
+The package exposes three products:
 
 - `FoundationModelsKit`: runtime inspection, capability use cases, model configuration, schemas, token accounting, transcript utilities, error projection, and conversation state.
 - `FoundationModelsTools`: `Tool` implementations for Apple platform capabilities and web services. This product re-exports `FoundationModelsKit`.
+- `FoundationModelsToolsTestSupport`: in-memory Calendar and Reminders services, scripted confirmation, and deterministic fixtures for downstream tests.
 
 ## What Is Included
 
@@ -189,17 +190,31 @@ do {
 
 ### Tools
 
-`FoundationModelsTools` provides tools for real app capabilities.
+`FoundationModelsTools` provides tools for real app capabilities. Calendar and Reminders reads are separate from mutations. Mutation tools cannot be initialized without an app-owned confirmation provider, and model-authored arguments never contain an approval flag.
 
 ```swift
 import FoundationModels
 import FoundationModelsTools
 
+let confirmation = ToolMutationConfirmationHandler { request in
+    // Present request.summary and request.details in app-owned UI.
+    let approved = await confirmationUI.confirm(request)
+    return approved
+        ? .approved()
+        : .denied(reason: "The user cancelled the change.")
+}
+
+// Share one long-lived EventKit store between each domain's read and mutation tools.
+let calendar = EventKitCalendarService()
+let reminders = EventKitRemindersService()
+
 let session = LanguageModelSession(
     tools: [
         WeatherTool(),
-        CalendarTool(),
-        RemindersTool()
+        CalendarReadTool(service: calendar),
+        RemindersReadTool(service: reminders),
+        CalendarMutationTool(service: calendar, confirmation: confirmation),
+        RemindersMutationTool(service: reminders, confirmation: confirmation)
     ]
 )
 
@@ -214,13 +229,30 @@ Available tools:
 - `WebTool`: Exa-backed web search
 - `WebMetadataTool`: page title, description, and image metadata
 - `ContactsTool`: search, read, and create contacts
-- `CalendarTool`: create, query, read, and update events
-- `RemindersTool`: create, query, update, complete, and delete reminders
+- `CalendarReadTool`: query and read events
+- `CalendarMutationTool`: create and update events after app-owned confirmation
+- `RemindersReadTool`: query reminders
+- `RemindersMutationTool`: create, update, complete, and delete reminders after app-owned confirmation
 - `LocationTool`: current location, geocoding, reverse geocoding, place search, and distance
 - `HealthTool`: authorized HealthKit reads
 - `MusicTool`: Apple Music search and playback controls
 
 The tools preserve platform permission boundaries. They do not fabricate unavailable Health, Contacts, Calendar, Location, Music, or Reminders data.
+
+### Mutation Safety
+
+Calendar and Reminders use four public boundaries:
+
+1. Read services (`CalendarReading` and `RemindersReading`) expose no write methods.
+2. Mutation services (`CalendarMutating` and `RemindersMutating`) are injected into mutation-only tools.
+3. `ToolMutationConfirming` belongs to the host app and reviews the exact `ToolMutationRequest` immediately before execution.
+4. Every executed mutation returns a typed `ToolMutationReceipt`, including the committed resource identifier. Failures throw `ToolMutationExecutionError` with the same receipt.
+
+Receipts distinguish `.notAttempted`, `.notCommitted`, `.committed`, and `.unknown`. An EventKit error after a save begins is intentionally `.unknown`; callers must not claim that a retry is safe when the system cannot prove whether the first write committed.
+
+The old `CalendarTool` and `RemindersTool` remain source-compatible for migration, but are deprecated. Their zero-argument initializers are read-capable and fail closed with a `.confirmationRequired` receipt for every mutation. Pass a confirmation provider explicitly, or migrate to the split tools.
+
+For tests, add the `FoundationModelsToolsTestSupport` product and inject `InMemoryCalendarService`, `InMemoryRemindersService`, and `ScriptedToolMutationConfirmer`. No Calendar or Reminders permission is needed for these fixtures.
 
 ## Requirements
 
@@ -239,7 +271,7 @@ Add the package dependency:
 dependencies: [
     .package(
         url: "https://github.com/rryam/FoundationModelsKit.git",
-        branch: "main"
+        from: "3.0.0"
     )
 ]
 ```
@@ -256,6 +288,20 @@ Use the core product, the tools product, or both:
         ),
         .product(
             name: "FoundationModelsTools",
+            package: "FoundationModelsKit"
+        )
+    ]
+)
+```
+
+Add `FoundationModelsToolsTestSupport` only to targets that need fixtures:
+
+```swift
+.testTarget(
+    name: "YourTargetTests",
+    dependencies: [
+        .product(
+            name: "FoundationModelsToolsTestSupport",
             package: "FoundationModelsKit"
         )
     ]

--- a/Sources/FoundationModelsTools/Services/CalendarService.swift
+++ b/Sources/FoundationModelsTools/Services/CalendarService.swift
@@ -1,0 +1,226 @@
+@preconcurrency import EventKit
+import Foundation
+
+public struct CalendarEventRecord: Codable, Hashable, Sendable {
+  public let id: String
+  public let title: String
+  public let startDate: Date
+  public let endDate: Date
+  public let location: String?
+  public let calendarTitle: String
+  public let notes: String?
+  public let isAllDay: Bool
+  public let url: URL?
+  public let hasAlarms: Bool
+
+  public init(
+    id: String,
+    title: String,
+    startDate: Date,
+    endDate: Date,
+    location: String? = nil,
+    calendarTitle: String,
+    notes: String? = nil,
+    isAllDay: Bool = false,
+    url: URL? = nil,
+    hasAlarms: Bool = false
+  ) {
+    self.id = id
+    self.title = title
+    self.startDate = startDate
+    self.endDate = endDate
+    self.location = location
+    self.calendarTitle = calendarTitle
+    self.notes = notes
+    self.isAllDay = isAllDay
+    self.url = url
+    self.hasAlarms = hasAlarms
+  }
+}
+
+public struct CalendarEventDraft: Codable, Hashable, Sendable {
+  public let title: String
+  public let startDate: Date
+  public let endDate: Date
+  public let location: String?
+  public let notes: String?
+  public let calendarName: String?
+
+  public init(
+    title: String,
+    startDate: Date,
+    endDate: Date,
+    location: String? = nil,
+    notes: String? = nil,
+    calendarName: String? = nil
+  ) {
+    self.title = title
+    self.startDate = startDate
+    self.endDate = endDate
+    self.location = location
+    self.notes = notes
+    self.calendarName = calendarName
+  }
+}
+
+public struct CalendarEventChanges: Codable, Hashable, Sendable {
+  public let title: String?
+  public let startDate: Date?
+  public let endDate: Date?
+  public let location: String?
+  public let notes: String?
+
+  public init(
+    title: String? = nil,
+    startDate: Date? = nil,
+    endDate: Date? = nil,
+    location: String? = nil,
+    notes: String? = nil
+  ) {
+    self.title = title
+    self.startDate = startDate
+    self.endDate = endDate
+    self.location = location
+    self.notes = notes
+  }
+}
+
+public protocol CalendarReading: Sendable {
+  func requestCalendarReadAccess() async throws -> Bool
+  func calendarEvents(from startDate: Date, to endDate: Date) async throws -> [CalendarEventRecord]
+  func calendarEvent(id: String) async throws -> CalendarEventRecord?
+}
+
+public protocol CalendarMutating: Sendable {
+  func requestCalendarMutationAccess() async throws -> Bool
+  func createCalendarEvent(_ draft: CalendarEventDraft) async throws -> CalendarEventRecord
+  func updateCalendarEvent(id: String, changes: CalendarEventChanges) async throws
+    -> CalendarEventRecord?
+}
+
+public actor EventKitCalendarService: CalendarReading, CalendarMutating {
+  private let eventStore: EKEventStore
+
+  public init(eventStore: EKEventStore = EKEventStore()) {
+    self.eventStore = eventStore
+  }
+
+  public func requestCalendarReadAccess() async throws -> Bool {
+    try await eventStore.requestFullAccessToEvents()
+  }
+
+  public func requestCalendarMutationAccess() async throws -> Bool {
+    try await eventStore.requestFullAccessToEvents()
+  }
+
+  public func calendarEvents(from startDate: Date, to endDate: Date) -> [CalendarEventRecord] {
+    let predicate = eventStore.predicateForEvents(
+      withStart: startDate,
+      end: endDate,
+      calendars: eventStore.calendars(for: .event)
+    )
+    return eventStore.events(matching: predicate).map { Self.record($0) }
+  }
+
+  public func calendarEvent(id: String) -> CalendarEventRecord? {
+    eventStore.event(withIdentifier: id).map { Self.record($0) }
+  }
+
+  public func createCalendarEvent(_ draft: CalendarEventDraft) throws -> CalendarEventRecord {
+    guard draft.endDate >= draft.startDate else {
+      throw ToolMutationOperationError(
+        failureDescription: CalendarToolError.endBeforeStart.localizedDescription,
+        commitState: .notAttempted
+      )
+    }
+
+    let event = EKEvent(eventStore: eventStore)
+    event.title = draft.title
+    event.startDate = draft.startDate
+    event.endDate = draft.endDate
+    event.location = draft.location
+    event.notes = draft.notes
+    event.calendar = calendar(named: draft.calendarName) ?? eventStore.defaultCalendarForNewEvents
+
+    do {
+      try eventStore.save(event, span: .thisEvent)
+    } catch {
+      throw ToolMutationOperationError(
+        failureDescription: error.localizedDescription,
+        commitState: .unknown
+      )
+    }
+
+    guard let identifier = event.eventIdentifier, !identifier.isEmpty else {
+      throw ToolMutationOperationError(
+        failureDescription: "Calendar saved the event but did not return an identifier.",
+        commitState: .unknown
+      )
+    }
+
+    return Self.record(event, identifier: identifier)
+  }
+
+  public func updateCalendarEvent(
+    id: String,
+    changes: CalendarEventChanges
+  ) throws -> CalendarEventRecord? {
+    guard let event = eventStore.event(withIdentifier: id) else {
+      return nil
+    }
+
+    if let title = changes.title {
+      event.title = title
+    }
+    if let startDate = changes.startDate {
+      event.startDate = startDate
+    }
+    if let endDate = changes.endDate {
+      event.endDate = endDate
+    }
+    if let location = changes.location {
+      event.location = location
+    }
+    if let notes = changes.notes {
+      event.notes = notes
+    }
+
+    guard event.endDate >= event.startDate else {
+      throw ToolMutationOperationError(
+        failureDescription: CalendarToolError.endBeforeStart.localizedDescription,
+        commitState: .notAttempted
+      )
+    }
+
+    do {
+      try eventStore.save(event, span: .thisEvent)
+    } catch {
+      throw ToolMutationOperationError(
+        failureDescription: error.localizedDescription,
+        commitState: .unknown
+      )
+    }
+
+    return Self.record(event, identifier: id)
+  }
+
+  private func calendar(named name: String?) -> EKCalendar? {
+    guard let name else { return nil }
+    return eventStore.calendars(for: .event).first { $0.title == name }
+  }
+
+  private static func record(_ event: EKEvent, identifier: String? = nil) -> CalendarEventRecord {
+    CalendarEventRecord(
+      id: identifier ?? event.eventIdentifier ?? "",
+      title: event.title ?? "Untitled",
+      startDate: event.startDate,
+      endDate: event.endDate,
+      location: event.location,
+      calendarTitle: event.calendar?.title ?? "Unknown Calendar",
+      notes: event.notes,
+      isAllDay: event.isAllDay,
+      url: event.url,
+      hasAlarms: !(event.alarms?.isEmpty ?? true)
+    )
+  }
+}

--- a/Sources/FoundationModelsTools/Services/RemindersService.swift
+++ b/Sources/FoundationModelsTools/Services/RemindersService.swift
@@ -1,0 +1,296 @@
+@preconcurrency import EventKit
+import Foundation
+
+public enum ReminderQueryFilter: String, Codable, Hashable, Sendable {
+  case all
+  case incomplete
+  case completed
+  case today
+  case overdue
+}
+
+public enum ReminderPriority: String, Codable, Hashable, Sendable {
+  case none
+  case low
+  case medium
+  case high
+
+  var eventKitValue: Int {
+    switch self {
+    case .none: 0
+    case .low: 9
+    case .medium: 5
+    case .high: 1
+    }
+  }
+
+  init(eventKitValue: Int) {
+    switch eventKitValue {
+    case 1...3: self = .high
+    case 4...6: self = .medium
+    case 7...9: self = .low
+    default: self = .none
+    }
+  }
+}
+
+public struct ReminderRecord: Codable, Hashable, Sendable {
+  public let id: String
+  public let title: String
+  public let listName: String
+  public let dueDate: Date?
+  public let priority: ReminderPriority
+  public let notes: String?
+  public let isCompleted: Bool
+  public let completionDate: Date?
+
+  public init(
+    id: String,
+    title: String,
+    listName: String,
+    dueDate: Date? = nil,
+    priority: ReminderPriority = .none,
+    notes: String? = nil,
+    isCompleted: Bool = false,
+    completionDate: Date? = nil
+  ) {
+    self.id = id
+    self.title = title
+    self.listName = listName
+    self.dueDate = dueDate
+    self.priority = priority
+    self.notes = notes
+    self.isCompleted = isCompleted
+    self.completionDate = completionDate
+  }
+}
+
+public struct ReminderDraft: Codable, Hashable, Sendable {
+  public let title: String
+  public let notes: String?
+  public let dueDate: Date?
+  public let priority: ReminderPriority
+  public let listName: String?
+
+  public init(
+    title: String,
+    notes: String? = nil,
+    dueDate: Date? = nil,
+    priority: ReminderPriority = .none,
+    listName: String? = nil
+  ) {
+    self.title = title
+    self.notes = notes
+    self.dueDate = dueDate
+    self.priority = priority
+    self.listName = listName
+  }
+}
+
+public struct ReminderChanges: Codable, Hashable, Sendable {
+  public let title: String?
+  public let notes: String?
+  public let dueDate: Date?
+  public let clearDueDate: Bool
+  public let priority: ReminderPriority?
+
+  public init(
+    title: String? = nil,
+    notes: String? = nil,
+    dueDate: Date? = nil,
+    clearDueDate: Bool = false,
+    priority: ReminderPriority? = nil
+  ) {
+    self.title = title
+    self.notes = notes
+    self.dueDate = dueDate
+    self.clearDueDate = clearDueDate
+    self.priority = priority
+  }
+}
+
+public protocol RemindersReading: Sendable {
+  func requestRemindersReadAccess() async throws -> Bool
+  func reminders(matching filter: ReminderQueryFilter, now: Date) async throws -> [ReminderRecord]
+}
+
+public protocol RemindersMutating: Sendable {
+  func requestRemindersMutationAccess() async throws -> Bool
+  func createReminder(_ draft: ReminderDraft) async throws -> ReminderRecord
+  func completeReminder(id: String, at date: Date) async throws -> ReminderRecord?
+  func updateReminder(id: String, changes: ReminderChanges) async throws -> ReminderRecord?
+  func deleteReminder(id: String) async throws -> ReminderRecord?
+}
+
+public actor EventKitRemindersService: RemindersReading, RemindersMutating {
+  private let eventStore: EKEventStore
+
+  public init(eventStore: EKEventStore = EKEventStore()) {
+    self.eventStore = eventStore
+  }
+
+  public func requestRemindersReadAccess() async throws -> Bool {
+    try await eventStore.requestFullAccessToReminders()
+  }
+
+  public func requestRemindersMutationAccess() async throws -> Bool {
+    try await eventStore.requestFullAccessToReminders()
+  }
+
+  public func reminders(
+    matching filter: ReminderQueryFilter,
+    now: Date
+  ) async -> [ReminderRecord] {
+    let calendars = eventStore.calendars(for: .reminder)
+    let predicate: NSPredicate
+
+    switch filter {
+    case .all:
+      predicate = eventStore.predicateForReminders(in: calendars)
+    case .completed:
+      predicate = eventStore.predicateForCompletedReminders(
+        withCompletionDateStarting: nil,
+        ending: nil,
+        calendars: calendars
+      )
+    case .today:
+      let startOfDay = Calendar.current.startOfDay(for: now)
+      let endOfDay = Calendar.current.date(byAdding: .day, value: 1, to: startOfDay) ?? now
+      predicate = eventStore.predicateForIncompleteReminders(
+        withDueDateStarting: startOfDay,
+        ending: endOfDay,
+        calendars: calendars
+      )
+    case .overdue:
+      predicate = eventStore.predicateForIncompleteReminders(
+        withDueDateStarting: nil,
+        ending: now,
+        calendars: calendars
+      )
+    case .incomplete:
+      predicate = eventStore.predicateForIncompleteReminders(
+        withDueDateStarting: nil,
+        ending: nil,
+        calendars: calendars
+      )
+    }
+
+    return await withCheckedContinuation { continuation in
+      eventStore.fetchReminders(matching: predicate) { reminders in
+        continuation.resume(returning: reminders?.map(Self.record) ?? [])
+      }
+    }
+  }
+
+  public func createReminder(_ draft: ReminderDraft) throws -> ReminderRecord {
+    let reminder = EKReminder(eventStore: eventStore)
+    reminder.title = draft.title
+    reminder.notes = draft.notes
+    reminder.dueDateComponents = Self.dateComponents(draft.dueDate)
+    reminder.priority = draft.priority.eventKitValue
+    reminder.calendar = list(named: draft.listName) ?? eventStore.defaultCalendarForNewReminders()
+
+    try save(reminder)
+
+    guard !reminder.calendarItemIdentifier.isEmpty else {
+      throw ToolMutationOperationError(
+        failureDescription: "Reminders saved the item but did not return an identifier.",
+        commitState: .unknown
+      )
+    }
+
+    return Self.record(reminder)
+  }
+
+  public func completeReminder(id: String, at date: Date) throws -> ReminderRecord? {
+    guard let reminder = eventStore.calendarItem(withIdentifier: id) as? EKReminder else {
+      return nil
+    }
+
+    reminder.isCompleted = true
+    reminder.completionDate = date
+    try save(reminder)
+    return Self.record(reminder)
+  }
+
+  public func updateReminder(
+    id: String,
+    changes: ReminderChanges
+  ) throws -> ReminderRecord? {
+    guard let reminder = eventStore.calendarItem(withIdentifier: id) as? EKReminder else {
+      return nil
+    }
+
+    if let title = changes.title {
+      reminder.title = title
+    }
+    if let notes = changes.notes {
+      reminder.notes = notes
+    }
+    if changes.clearDueDate {
+      reminder.dueDateComponents = nil
+    } else if let dueDate = changes.dueDate {
+      reminder.dueDateComponents = Self.dateComponents(dueDate)
+    }
+    if let priority = changes.priority {
+      reminder.priority = priority.eventKitValue
+    }
+
+    try save(reminder)
+    return Self.record(reminder)
+  }
+
+  public func deleteReminder(id: String) throws -> ReminderRecord? {
+    guard let reminder = eventStore.calendarItem(withIdentifier: id) as? EKReminder else {
+      return nil
+    }
+
+    let record = Self.record(reminder)
+    do {
+      try eventStore.remove(reminder, commit: true)
+    } catch {
+      throw ToolMutationOperationError(
+        failureDescription: error.localizedDescription,
+        commitState: .unknown
+      )
+    }
+    return record
+  }
+
+  private func list(named name: String?) -> EKCalendar? {
+    guard let name else { return nil }
+    return eventStore.calendars(for: .reminder).first { $0.title == name }
+  }
+
+  private func save(_ reminder: EKReminder) throws {
+    do {
+      try eventStore.save(reminder, commit: true)
+    } catch {
+      throw ToolMutationOperationError(
+        failureDescription: error.localizedDescription,
+        commitState: .unknown
+      )
+    }
+  }
+
+  private static func dateComponents(_ date: Date?) -> DateComponents? {
+    guard let date else { return nil }
+    return Calendar.current.dateComponents(
+      [.year, .month, .day, .hour, .minute],
+      from: date
+    )
+  }
+
+  private static func record(_ reminder: EKReminder) -> ReminderRecord {
+    ReminderRecord(
+      id: reminder.calendarItemIdentifier,
+      title: reminder.title ?? "Untitled",
+      listName: reminder.calendar?.title ?? "Unknown List",
+      dueDate: reminder.dueDateComponents?.date,
+      priority: ReminderPriority(eventKitValue: reminder.priority),
+      notes: reminder.notes,
+      isCompleted: reminder.isCompleted,
+      completionDate: reminder.completionDate
+    )
+  }
+}

--- a/Sources/FoundationModelsTools/Support/ToolMutationSafety.swift
+++ b/Sources/FoundationModelsTools/Support/ToolMutationSafety.swift
@@ -1,0 +1,264 @@
+import Foundation
+
+/// Whether a tool mutation reached durable system state.
+public enum ToolMutationCommitState: String, Codable, Hashable, Sendable {
+  /// The mutation operation was never invoked.
+  case notAttempted
+  /// The service confirmed that the mutation committed.
+  case committed
+  /// The service confirmed that the mutation did not commit.
+  case notCommitted
+  /// The service failed after execution began and cannot prove whether it committed.
+  case unknown
+}
+
+/// The terminal status recorded for a tool mutation request.
+public enum ToolMutationReceiptStatus: String, Codable, Hashable, Sendable {
+  case confirmationRequired
+  case denied
+  case succeeded
+  case failed
+}
+
+/// An app-reviewable description of a proposed real-world mutation.
+public struct ToolMutationDetail: Codable, Hashable, Sendable {
+  public let label: String
+  public let value: String
+
+  public init(label: String, value: String) {
+    self.label = label
+    self.value = value
+  }
+}
+
+/// An app-reviewable description of a proposed real-world mutation.
+public struct ToolMutationRequest: Codable, Hashable, Sendable {
+  public let id: UUID
+  public let toolName: String
+  public let action: String
+  public let summary: String
+  public let details: [ToolMutationDetail]
+  public let resourceID: String?
+  public let isDestructive: Bool
+
+  public init(
+    id: UUID = UUID(),
+    toolName: String,
+    action: String,
+    summary: String,
+    details: [ToolMutationDetail] = [],
+    resourceID: String? = nil,
+    isDestructive: Bool = false
+  ) {
+    self.id = id
+    self.toolName = toolName
+    self.action = action
+    self.summary = summary
+    self.details = details
+    self.resourceID = resourceID
+    self.isDestructive = isDestructive
+  }
+}
+
+/// An app-owned decision about a proposed tool mutation.
+public struct ToolMutationDecision: Codable, Hashable, Sendable {
+  public let isApproved: Bool
+  public let reason: String?
+
+  public init(isApproved: Bool, reason: String? = nil) {
+    self.isApproved = isApproved
+    self.reason = reason
+  }
+
+  public static func approved() -> Self {
+    Self(isApproved: true)
+  }
+
+  public static func denied(reason: String? = nil) -> Self {
+    Self(isApproved: false, reason: reason)
+  }
+}
+
+/// Implemented by the host app so model-authored arguments cannot approve their own mutation.
+public protocol ToolMutationConfirming: Sendable {
+  func confirmation(for request: ToolMutationRequest) async throws -> ToolMutationDecision
+}
+
+/// Adapts an app-owned async closure into a mutation confirmer.
+public struct ToolMutationConfirmationHandler: ToolMutationConfirming {
+  private let handler: @Sendable (ToolMutationRequest) async throws -> ToolMutationDecision
+
+  public init(
+    _ handler: @escaping @Sendable (ToolMutationRequest) async throws -> ToolMutationDecision
+  ) {
+    self.handler = handler
+  }
+
+  public func confirmation(for request: ToolMutationRequest) async throws -> ToolMutationDecision {
+    try await handler(request)
+  }
+}
+
+/// A durable, truthful account of what happened to a proposed mutation.
+public struct ToolMutationReceipt: Codable, Hashable, Sendable {
+  public let request: ToolMutationRequest
+  public let status: ToolMutationReceiptStatus
+  public let commitState: ToolMutationCommitState
+  public let message: String
+  public let resourceID: String?
+  public let timestamp: Date
+
+  public init(
+    request: ToolMutationRequest,
+    status: ToolMutationReceiptStatus,
+    commitState: ToolMutationCommitState,
+    message: String,
+    resourceID: String? = nil,
+    timestamp: Date = Date()
+  ) {
+    self.request = request
+    self.status = status
+    self.commitState = commitState
+    self.message = message
+    self.resourceID = resourceID
+    self.timestamp = timestamp
+  }
+}
+
+/// The typed value and receipt returned after a confirmed mutation commits.
+public struct ToolMutationExecution<Value: Sendable>: Sendable {
+  public let value: Value
+  public let receipt: ToolMutationReceipt
+
+  public init(value: Value, receipt: ToolMutationReceipt) {
+    self.value = value
+    self.receipt = receipt
+  }
+}
+
+/// A mutation failure carrying the receipt that callers should persist or display.
+public struct ToolMutationExecutionError: Error, LocalizedError, Sendable {
+  public let receipt: ToolMutationReceipt
+
+  public init(receipt: ToolMutationReceipt) {
+    self.receipt = receipt
+  }
+
+  public var errorDescription: String? {
+    receipt.message
+  }
+
+  public static func confirmationRequired(for request: ToolMutationRequest) -> Self {
+    Self(
+      receipt: ToolMutationReceipt(
+        request: request,
+        status: .confirmationRequired,
+        commitState: .notAttempted,
+        message: "The host app must explicitly confirm this mutation before it can run."
+      )
+    )
+  }
+}
+
+/// An error a service can throw when it knows whether a failed operation committed.
+public struct ToolMutationOperationError: Error, LocalizedError, Sendable {
+  public let failureDescription: String
+  public let commitState: ToolMutationCommitState
+
+  public init(
+    failureDescription: String,
+    commitState: ToolMutationCommitState
+  ) {
+    self.failureDescription = failureDescription
+    self.commitState = commitState
+  }
+
+  public var errorDescription: String? {
+    failureDescription
+  }
+}
+
+/// Executes mutations only after an app-owned confirmer approves the exact request.
+public struct ToolMutationExecutor: Sendable {
+  private let confirmer: any ToolMutationConfirming
+  private let now: @Sendable () -> Date
+
+  public init(
+    confirmer: any ToolMutationConfirming,
+    now: @escaping @Sendable () -> Date = Date.init
+  ) {
+    self.confirmer = confirmer
+    self.now = now
+  }
+
+  public func execute<Value: Sendable>(
+    _ request: ToolMutationRequest,
+    resourceID: @escaping @Sendable (Value) -> String? = { _ in nil },
+    operation: @escaping @Sendable () async throws -> Value
+  ) async throws -> ToolMutationExecution<Value> {
+    let decision: ToolMutationDecision
+
+    do {
+      decision = try await confirmer.confirmation(for: request)
+    } catch {
+      throw failure(
+        request: request,
+        message: "Confirmation failed: \(error.localizedDescription)",
+        commitState: .notAttempted
+      )
+    }
+
+    guard decision.isApproved else {
+      throw ToolMutationExecutionError(
+        receipt: ToolMutationReceipt(
+          request: request,
+          status: .denied,
+          commitState: .notAttempted,
+          message: decision.reason ?? "The host app denied this mutation.",
+          timestamp: now()
+        )
+      )
+    }
+
+    do {
+      let value = try await operation()
+      let receipt = ToolMutationReceipt(
+        request: request,
+        status: .succeeded,
+        commitState: .committed,
+        message: "Mutation committed successfully.",
+        resourceID: resourceID(value) ?? request.resourceID,
+        timestamp: now()
+      )
+      return ToolMutationExecution(value: value, receipt: receipt)
+    } catch let error as ToolMutationOperationError {
+      throw failure(
+        request: request,
+        message: error.failureDescription,
+        commitState: error.commitState
+      )
+    } catch {
+      throw failure(
+        request: request,
+        message: error.localizedDescription,
+        commitState: .unknown
+      )
+    }
+  }
+
+  private func failure(
+    request: ToolMutationRequest,
+    message: String,
+    commitState: ToolMutationCommitState
+  ) -> ToolMutationExecutionError {
+    ToolMutationExecutionError(
+      receipt: ToolMutationReceipt(
+        request: request,
+        status: .failed,
+        commitState: commitState,
+        message: message,
+        timestamp: now()
+      )
+    )
+  }
+}

--- a/Sources/FoundationModelsTools/Tools/CalendarTool.swift
+++ b/Sources/FoundationModelsTools/Tools/CalendarTool.swift
@@ -1,78 +1,444 @@
-//
-//  CalendarTool.swift
-//  FoundationLab
-//
-//  Created by Rudrank Riyam on 6/17/25.
-//
-
-@preconcurrency import EventKit
 import Foundation
 import FoundationModels
 import FoundationModelsKit
 
-/// A tool for managing calendar events using EventKit.
-///
-/// Use `CalendarTool` to create, read, query, and update calendar events.
-/// It integrates with the system Calendar app and requires appropriate permissions.
-///
-/// The following actions are supported:
-/// - `create`: Create a new calendar event
-/// - `query`: Query upcoming events within a date range
-/// - `read`: Read details of a specific event by ID
-/// - `update`: Update an existing event
-///
-/// ```swift
-/// let session = LanguageModelSession(tools: [CalendarTool()])
-/// let response = try await session.respond(to: "Create a meeting tomorrow at 2pm")
-/// ```
-///
-/// - Important: Requires Calendar entitlement, `NSCalendarsUsageDescription` in Info.plist,
-///   and user permission at runtime.
-public struct CalendarTool: Tool {
+/// Read-only Calendar access. This tool cannot create or update events.
+public struct CalendarReadTool: Tool {
+  public let name = "readCalendar"
+  public let description = "Query calendar events or read one event by identifier"
 
-  /// The name of the tool, used for identification.
-  public let name = "manageCalendar"
-  /// A brief description of the tool's functionality.
-  public let description = "Create, read, and query calendar events"
-
-  /// Arguments for calendar operations.
   @Generable
   public struct Arguments: RuntimeCompatibleGenerable {
-    /// The action to perform: "create", "query", "read", "update"
-    @Guide(description: "The action to perform: 'create', 'query', 'read', 'update'")
+    @Guide(description: "The read action to perform: 'query' or 'read'")
     public var action: String
 
-    /// Event title for creating or updating
+    @Guide(description: "Number of upcoming days to query")
+    public var daysAhead: Int?
+
+    @Guide(description: "Event identifier for the read action")
+    public var eventId: String?
+
+    public init(
+      action: String = "",
+      daysAhead: Int? = nil,
+      eventId: String? = nil
+    ) {
+      self.action = action
+      self.daysAhead = daysAhead
+      self.eventId = eventId
+    }
+  }
+
+  private let service: any CalendarReading
+  private let now: @Sendable () -> Date
+
+  public init(
+    service: any CalendarReading,
+    now: @escaping @Sendable () -> Date = Date.init
+  ) {
+    self.service = service
+    self.now = now
+  }
+
+  public func call(arguments: Arguments) async throws -> GeneratedContent {
+    let authorized: Bool
+    do {
+      authorized = try await service.requestCalendarReadAccess()
+    } catch {
+      throw CalendarToolError.accessDenied
+    }
+    guard authorized else {
+      throw CalendarToolError.accessDenied
+    }
+
+    switch arguments.action.lowercased() {
+    case "query":
+      return try await query(daysAhead: arguments.daysAhead ?? 7)
+    case "read":
+      return try await read(eventID: arguments.eventId)
+    default:
+      throw CalendarToolError.invalidReadAction
+    }
+  }
+
+  private func query(daysAhead: Int) async throws -> GeneratedContent {
+    let startDate = now()
+    guard let endDate = Calendar.current.date(byAdding: .day, value: daysAhead, to: startDate)
+    else {
+      throw CalendarToolError.invalidEndDate
+    }
+
+    let events = try await service.calendarEvents(from: startDate, to: endDate)
+    let description = Self.formatEventQueryResults(events)
+
+    return GeneratedContent(properties: [
+      "status": "success",
+      "count": events.count,
+      "daysQueried": daysAhead,
+      "eventIds": events.map(\.id),
+      "events": description.isEmpty
+        ? "No events found in the next \(daysAhead) days"
+        : description.trimmingCharacters(in: .whitespacesAndNewlines),
+      "message": "Found \(events.count) event(s) in the next \(daysAhead) days"
+    ])
+  }
+
+  private func read(eventID: String?) async throws -> GeneratedContent {
+    guard let eventID, !eventID.isEmpty else {
+      throw CalendarToolError.missingEventID
+    }
+    guard let event = try await service.calendarEvent(id: eventID) else {
+      throw CalendarToolError.eventNotFound
+    }
+
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateStyle = .full
+    dateFormatter.timeStyle = .short
+
+    return GeneratedContent(properties: [
+      "status": "success",
+      "eventId": event.id,
+      "title": event.title,
+      "startDate": CalendarToolDateFormatter.string(from: event.startDate),
+      "endDate": CalendarToolDateFormatter.string(from: event.endDate),
+      "location": event.location ?? "",
+      "notes": event.notes ?? "",
+      "calendar": event.calendarTitle,
+      "isAllDay": event.isAllDay,
+      "url": event.url?.absoluteString ?? "",
+      "hasAlarms": event.hasAlarms,
+      "formattedDate":
+        "\(dateFormatter.string(from: event.startDate)) - \(dateFormatter.string(from: event.endDate))"
+    ])
+  }
+
+  static func formatEventQueryResults(_ events: [CalendarEventRecord]) -> String {
+    events.enumerated().map { index, event in
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateStyle = .medium
+      dateFormatter.timeStyle = .short
+
+      var lines = [
+        "\(index + 1). \(event.title)",
+        "   Event ID: \(event.id)",
+        "   When: \(dateFormatter.string(from: event.startDate)) - "
+          + dateFormatter.string(from: event.endDate),
+        "   Calendar: \(event.calendarTitle)"
+          + (event.location.map { " at \($0)" } ?? "")
+      ]
+      if let notes = event.notes, !notes.isEmpty {
+        lines.append("   Notes: \(notes.prefix(50))...")
+      }
+      return lines.joined(separator: "\n")
+    }.joined(separator: "\n\n")
+  }
+}
+
+/// Calendar mutations guarded by an app-owned confirmation provider.
+public struct CalendarMutationTool: Tool {
+  public let name = "mutateCalendar"
+  public let description = "Create or update a calendar event after host-app confirmation"
+
+  @Generable
+  public struct Arguments: RuntimeCompatibleGenerable {
+    @Guide(description: "The mutation action to perform: 'create' or 'update'")
+    public var action: String
+
     @Guide(description: "Event title for creating or updating")
     public var title: String?
 
-    /// Start date in ISO format (YYYY-MM-DD HH:mm:ss)
-    @Guide(description: "Start date in ISO format (YYYY-MM-DD HH:mm:ss)")
+    @Guide(description: "Start date in format YYYY-MM-DD HH:mm:ss")
     public var startDate: String?
 
-    /// End date in ISO format (YYYY-MM-DD HH:mm:ss)
-    @Guide(description: "End date in ISO format (YYYY-MM-DD HH:mm:ss)")
+    @Guide(description: "End date in format YYYY-MM-DD HH:mm:ss")
     public var endDate: String?
 
-    /// Location for the event
-    @Guide(description: "Location for the event")
+    @Guide(description: "Event location")
     public var location: String?
 
-    /// Notes for the event
-    @Guide(description: "Notes for the event")
+    @Guide(description: "Event notes")
     public var notes: String?
 
-    /// Calendar name to use (defaults to default calendar)
-    @Guide(description: "Calendar name to use (defaults to default calendar)")
+    @Guide(description: "Calendar name; the default calendar is used when omitted")
     public var calendarName: String?
 
-    /// Number of days to query (for query action)
-    @Guide(description: "Number of days to query (for query action)")
-    public var daysAhead: Int?
-
-    /// Event identifier for reading or updating specific event
-    @Guide(description: "Event identifier for reading or updating specific event")
+    @Guide(description: "Event identifier for the update action")
     public var eventId: String?
+
+    public init(
+      action: String = "",
+      title: String? = nil,
+      startDate: String? = nil,
+      endDate: String? = nil,
+      location: String? = nil,
+      notes: String? = nil,
+      calendarName: String? = nil,
+      eventId: String? = nil
+    ) {
+      self.action = action
+      self.title = title
+      self.startDate = startDate
+      self.endDate = endDate
+      self.location = location
+      self.notes = notes
+      self.calendarName = calendarName
+      self.eventId = eventId
+    }
+  }
+
+  private enum PreparedMutation: Sendable {
+    case create(CalendarEventDraft)
+    case update(id: String, changes: CalendarEventChanges)
+  }
+
+  private let service: any CalendarMutating
+  private let executor: ToolMutationExecutor
+
+  public init(
+    service: any CalendarMutating,
+    confirmation: any ToolMutationConfirming
+  ) {
+    self.service = service
+    self.executor = ToolMutationExecutor(confirmer: confirmation)
+  }
+
+  init(service: any CalendarMutating, executor: ToolMutationExecutor) {
+    self.service = service
+    self.executor = executor
+  }
+
+  public func execute(
+    arguments: Arguments
+  ) async throws -> ToolMutationExecution<CalendarEventRecord> {
+    let prepared = try prepare(arguments)
+    let request = mutationRequest(for: prepared)
+    let service = service
+
+    return try await executor.execute(
+      request,
+      resourceID: { $0.id },
+      operation: {
+        let authorized: Bool
+        do {
+          authorized = try await service.requestCalendarMutationAccess()
+        } catch {
+          throw ToolMutationOperationError(
+            failureDescription: error.localizedDescription,
+            commitState: .notAttempted
+          )
+        }
+
+        guard authorized else {
+          throw ToolMutationOperationError(
+            failureDescription: CalendarToolError.accessDenied.localizedDescription,
+            commitState: .notAttempted
+          )
+        }
+
+        do {
+          switch prepared {
+          case .create(let draft):
+            return try await service.createCalendarEvent(draft)
+          case .update(let id, let changes):
+            guard let event = try await service.updateCalendarEvent(id: id, changes: changes) else {
+              throw ToolMutationOperationError(
+                failureDescription: CalendarToolError.eventNotFound.localizedDescription,
+                commitState: .notAttempted
+              )
+            }
+            return event
+          }
+        } catch let error as ToolMutationOperationError {
+          throw error
+        } catch {
+          throw ToolMutationOperationError(
+            failureDescription: error.localizedDescription,
+            commitState: .unknown
+          )
+        }
+      }
+    )
+  }
+
+  public func call(arguments: Arguments) async throws -> GeneratedContent {
+    let execution = try await execute(arguments: arguments)
+    let event = execution.value
+    let action = execution.receipt.request.action
+
+    return GeneratedContent(properties: [
+      "status": "success",
+      "message": action == "create" ? "Event created successfully" : "Event updated successfully",
+      "receiptId": execution.receipt.request.id.uuidString,
+      "receiptStatus": execution.receipt.status.rawValue,
+      "commitState": execution.receipt.commitState.rawValue,
+      "eventId": event.id,
+      "title": event.title,
+      "startDate": CalendarToolDateFormatter.string(from: event.startDate),
+      "endDate": CalendarToolDateFormatter.string(from: event.endDate),
+      "location": event.location ?? "",
+      "calendar": event.calendarTitle
+    ])
+  }
+
+  private func prepare(_ arguments: Arguments) throws -> PreparedMutation {
+    switch arguments.action.lowercased() {
+    case "create":
+      guard let title = arguments.title?.trimmingCharacters(in: .whitespacesAndNewlines),
+        !title.isEmpty
+      else {
+        throw CalendarToolError.missingTitle
+      }
+      guard let startDateText = arguments.startDate,
+        let startDate = CalendarToolDateFormatter.date(from: startDateText)
+      else {
+        throw CalendarToolError.invalidStartDate
+      }
+
+      let endDate: Date
+      if let endDateText = arguments.endDate {
+        guard let parsed = CalendarToolDateFormatter.date(from: endDateText) else {
+          throw CalendarToolError.invalidEndDate
+        }
+        endDate = parsed
+      } else {
+        endDate = startDate.addingTimeInterval(3_600)
+      }
+      guard endDate >= startDate else {
+        throw CalendarToolError.endBeforeStart
+      }
+
+      return .create(
+        CalendarEventDraft(
+          title: title,
+          startDate: startDate,
+          endDate: endDate,
+          location: arguments.location,
+          notes: arguments.notes,
+          calendarName: arguments.calendarName
+        )
+      )
+    case "update":
+      guard let eventID = arguments.eventId, !eventID.isEmpty else {
+        throw CalendarToolError.missingEventID
+      }
+      guard
+        arguments.title != nil || arguments.startDate != nil || arguments.endDate != nil
+          || arguments.location != nil || arguments.notes != nil
+      else {
+        throw CalendarToolError.noChanges
+      }
+      let startDate = try parseOptional(arguments.startDate, error: .invalidStartDate)
+      let endDate = try parseOptional(arguments.endDate, error: .invalidEndDate)
+      if let startDate, let endDate, endDate < startDate {
+        throw CalendarToolError.endBeforeStart
+      }
+      return .update(
+        id: eventID,
+        changes: CalendarEventChanges(
+          title: arguments.title,
+          startDate: startDate,
+          endDate: endDate,
+          location: arguments.location,
+          notes: arguments.notes
+        )
+      )
+    default:
+      throw CalendarToolError.invalidMutationAction
+    }
+  }
+
+  private func parseOptional(
+    _ value: String?,
+    error: CalendarToolError
+  ) throws -> Date? {
+    guard let value else { return nil }
+    guard let date = CalendarToolDateFormatter.date(from: value) else {
+      throw error
+    }
+    return date
+  }
+
+  private func mutationRequest(for mutation: PreparedMutation) -> ToolMutationRequest {
+    switch mutation {
+    case .create(let draft):
+      ToolMutationRequest(
+        toolName: name,
+        action: "create",
+        summary: "Create calendar event '\(draft.title)' from "
+          + "\(CalendarToolDateFormatter.string(from: draft.startDate)) to "
+          + CalendarToolDateFormatter.string(from: draft.endDate),
+        details: mutationDetails(for: draft)
+      )
+    case .update(let id, let changes):
+      ToolMutationRequest(
+        toolName: name,
+        action: "update",
+        summary: "Update calendar event '\(changes.title ?? id)'",
+        details: mutationDetails(for: changes),
+        resourceID: id
+      )
+    }
+  }
+
+  private func mutationDetails(for draft: CalendarEventDraft) -> [ToolMutationDetail] {
+    [
+      ToolMutationDetail(label: "Title", value: draft.title),
+      ToolMutationDetail(
+        label: "Start",
+        value: CalendarToolDateFormatter.string(from: draft.startDate)
+      ),
+      ToolMutationDetail(
+        label: "End",
+        value: CalendarToolDateFormatter.string(from: draft.endDate)
+      ),
+      optionalDetail(label: "Location", value: draft.location),
+      optionalDetail(label: "Notes", value: draft.notes),
+      optionalDetail(label: "Calendar", value: draft.calendarName)
+    ].compactMap { $0 }
+  }
+
+  private func mutationDetails(for changes: CalendarEventChanges) -> [ToolMutationDetail] {
+    [
+      optionalDetail(label: "Title", value: changes.title),
+      changes.startDate.map {
+        ToolMutationDetail(label: "Start", value: CalendarToolDateFormatter.string(from: $0))
+      },
+      changes.endDate.map {
+        ToolMutationDetail(label: "End", value: CalendarToolDateFormatter.string(from: $0))
+      },
+      optionalDetail(label: "Location", value: changes.location),
+      optionalDetail(label: "Notes", value: changes.notes)
+    ].compactMap { $0 }
+  }
+
+  private func optionalDetail(label: String, value: String?) -> ToolMutationDetail? {
+    value.map { ToolMutationDetail(label: label, value: $0) }
+  }
+}
+
+/// Backward-compatible combined Calendar tool. New code should register split read and mutation tools.
+@available(
+  *,
+  deprecated,
+  message:
+    "Use CalendarReadTool and CalendarMutationTool so mutations require explicit confirmation."
+)
+public struct CalendarTool: Tool {
+  public let name = "manageCalendar"
+  public let description = "Read calendar events; mutations require host-app confirmation"
+
+  @Generable
+  public struct Arguments: RuntimeCompatibleGenerable {
+    @Guide(description: "The action: 'create', 'query', 'read', or 'update'")
+    public var action: String
+    @Guide(description: "Event title") public var title: String?
+    @Guide(description: "Start date in format YYYY-MM-DD HH:mm:ss") public var startDate: String?
+    @Guide(description: "End date in format YYYY-MM-DD HH:mm:ss") public var endDate: String?
+    @Guide(description: "Event location") public var location: String?
+    @Guide(description: "Event notes") public var notes: String?
+    @Guide(description: "Calendar name") public var calendarName: String?
+    @Guide(description: "Number of upcoming days to query") public var daysAhead: Int?
+    @Guide(description: "Event identifier") public var eventId: String?
 
     public init(
       action: String = "",
@@ -97,334 +463,135 @@ public struct CalendarTool: Tool {
     }
   }
 
-  nonisolated(unsafe) private let eventStore = EKEventStore()
+  private let readTool: CalendarReadTool
+  private let mutationTool: CalendarMutationTool?
 
-  public init() {}
+  public init() {
+    let service = EventKitCalendarService()
+    self.readTool = CalendarReadTool(service: service)
+    self.mutationTool = nil
+  }
+
+  public init(
+    readService: any CalendarReading,
+    mutationService: any CalendarMutating,
+    confirmation: any ToolMutationConfirming
+  ) {
+    self.readTool = CalendarReadTool(service: readService)
+    self.mutationTool = CalendarMutationTool(
+      service: mutationService,
+      confirmation: confirmation
+    )
+  }
+
+  public init(confirmation: any ToolMutationConfirming) {
+    let service = EventKitCalendarService()
+    self.init(
+      readService: service,
+      mutationService: service,
+      confirmation: confirmation
+    )
+  }
 
   public func call(arguments: Arguments) async throws -> some PromptRepresentable {
-    // Request access if needed
-    let authorized = await requestAccess()
-    guard authorized else {
-      return createErrorOutput(error: CalendarError.accessDenied)
-    }
-
     switch arguments.action.lowercased() {
-    case "create":
-      return try createEvent(arguments: arguments)
-    case "query":
-      return try queryEvents(arguments: arguments)
-    case "read":
-      return try readEvent(eventId: arguments.eventId)
-    case "update":
-      return try updateEvent(arguments: arguments)
+    case "query", "read":
+      return try await readTool.call(
+        arguments: CalendarReadTool.Arguments(
+          action: arguments.action,
+          daysAhead: arguments.daysAhead,
+          eventId: arguments.eventId
+        )
+      )
+    case "create", "update":
+      guard let mutationTool else {
+        throw ToolMutationExecutionError.confirmationRequired(
+          for: ToolMutationRequest(
+            toolName: "mutateCalendar",
+            action: arguments.action.lowercased(),
+            summary: "Calendar mutation requested by deprecated CalendarTool",
+            resourceID: arguments.eventId
+          )
+        )
+      }
+      return try await mutationTool.call(
+        arguments: CalendarMutationTool.Arguments(
+          action: arguments.action,
+          title: arguments.title,
+          startDate: arguments.startDate,
+          endDate: arguments.endDate,
+          location: arguments.location,
+          notes: arguments.notes,
+          calendarName: arguments.calendarName,
+          eventId: arguments.eventId
+        )
+      )
     default:
-      return createErrorOutput(error: CalendarError.invalidAction)
+      throw CalendarToolError.invalidAction
     }
   }
 
-  private func requestAccess() async -> Bool {
-    do {
-      if #available(macOS 14.0, iOS 17.0, *) {
-        return try await eventStore.requestFullAccessToEvents()
-      } else {
-        return try await eventStore.requestAccess(to: .event)
-      }
-    } catch {
-      return false
-    }
-  }
-
-  private func createEvent(arguments: Arguments) throws -> GeneratedContent {
-    guard let title = arguments.title, !title.isEmpty else {
-      return createErrorOutput(error: CalendarError.missingTitle)
-    }
-
-    guard let startDateString = arguments.startDate,
-      let startDate = parseDate(startDateString)
-    else {
-      return createErrorOutput(error: CalendarError.invalidStartDate)
-    }
-
-    let endDate: Date
-    if let endDateString = arguments.endDate {
-      guard let parsedEndDate = parseDate(endDateString) else {
-        return createErrorOutput(error: CalendarError.invalidEndDate)
-      }
-      endDate = parsedEndDate
-    } else {
-      // Default to 1 hour duration
-      endDate = startDate.addingTimeInterval(3600)
-    }
-
-    let event = EKEvent(eventStore: eventStore)
-    event.title = title
-    event.startDate = startDate
-    event.endDate = endDate
-
-    if let location = arguments.location {
-      event.location = location
-    }
-
-    if let notes = arguments.notes {
-      event.notes = notes
-    }
-
-    // Set calendar
-    if let calendarName = arguments.calendarName {
-      let calendars = eventStore.calendars(for: .event)
-      if let calendar = calendars.first(where: { $0.title == calendarName }) {
-        event.calendar = calendar
-      } else {
-        event.calendar = eventStore.defaultCalendarForNewEvents
-      }
-    } else {
-      event.calendar = eventStore.defaultCalendarForNewEvents
-    }
-
-    do {
-      try eventStore.save(event, span: .thisEvent)
-
-      return GeneratedContent(properties: [
-        "status": "success",
-        "message": "Event created successfully",
-        "eventId": event.eventIdentifier ?? "",
-        "title": event.title ?? "",
-        "startDate": formatDate(event.startDate),
-        "endDate": formatDate(event.endDate),
-        "location": event.location ?? "",
-        "calendar": event.calendar?.title ?? ""
-      ])
-    } catch {
-      return createErrorOutput(error: error)
-    }
-  }
-
-  private func queryEvents(arguments: Arguments) throws -> GeneratedContent {
-    let startDate = Date()
-    let daysToQuery = arguments.daysAhead ?? 7
-    guard let endDate = Calendar.current.date(byAdding: .day, value: daysToQuery, to: startDate) else {
-      return createErrorOutput(error: CalendarError.invalidEndDate)
-    }
-
-    let calendars = eventStore.calendars(for: .event)
-
-    let predicate = eventStore.predicateForEvents(
-      withStart: startDate,
-      end: endDate,
-      calendars: calendars
-    )
-
-    let events = eventStore.events(matching: predicate)
-
-    let eventSummaries = events.map(CalendarEventSummary.init)
-    var eventsDescription = Self.formatEventQueryResults(eventSummaries)
-
-    if eventsDescription.isEmpty {
-      eventsDescription = "No events found in the next \(daysToQuery) days"
-    }
-
-    return GeneratedContent(properties: [
-      "status": "success",
-      "count": events.count,
-      "daysQueried": daysToQuery,
-      "eventIds": eventSummaries.map(\.id),
-      "events": eventsDescription.trimmingCharacters(in: .whitespacesAndNewlines),
-      "message": "Found \(events.count) event(s) in the next \(daysToQuery) days"
-    ])
-  }
-
-  private func readEvent(eventId: String?) throws -> GeneratedContent {
-    guard let id = eventId else {
-      return createErrorOutput(error: CalendarError.missingEventId)
-    }
-
-    guard let event = eventStore.event(withIdentifier: id) else {
-      return createErrorOutput(error: CalendarError.eventNotFound)
-    }
-
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateStyle = .full
-    dateFormatter.timeStyle = .short
-
-    return GeneratedContent(properties: [
-      "status": "success",
-      "eventId": event.eventIdentifier ?? "",
-      "title": event.title ?? "",
-      "startDate": formatDate(event.startDate),
-      "endDate": formatDate(event.endDate),
-      "location": event.location ?? "",
-      "notes": event.notes ?? "",
-      "calendar": event.calendar?.title ?? "",
-      "isAllDay": event.isAllDay,
-      "url": event.url?.absoluteString ?? "",
-      "hasAlarms": !(event.alarms?.isEmpty ?? true),
-      "formattedDate":
-        "\(dateFormatter.string(from: event.startDate)) - \(dateFormatter.string(from: event.endDate))"
-    ])
-  }
-
-  private func updateEvent(arguments: Arguments) throws -> GeneratedContent {
-    guard let eventId = arguments.eventId else {
-      return createErrorOutput(error: CalendarError.missingEventId)
-    }
-
-    guard let event = eventStore.event(withIdentifier: eventId) else {
-      return createErrorOutput(error: CalendarError.eventNotFound)
-    }
-
-    // Update fields if provided
-    if let title = arguments.title {
-      event.title = title
-    }
-
-    if let startDateString = arguments.startDate,
-      let startDate = parseDate(startDateString) {
-      event.startDate = startDate
-    }
-
-    if let endDateString = arguments.endDate,
-      let endDate = parseDate(endDateString) {
-      event.endDate = endDate
-    }
-
-    if let location = arguments.location {
-      event.location = location
-    }
-
-    if let notes = arguments.notes {
-      event.notes = notes
-    }
-
-    do {
-      try eventStore.save(event, span: .thisEvent)
-
-      return GeneratedContent(properties: [
-        "status": "success",
-        "message": "Event updated successfully",
-        "eventId": event.eventIdentifier ?? "",
-        "title": event.title ?? "",
-        "startDate": formatDate(event.startDate),
-        "endDate": formatDate(event.endDate),
-        "location": event.location ?? "",
-        "calendar": event.calendar?.title ?? ""
-      ])
-    } catch {
-      return createErrorOutput(error: error)
-    }
-  }
-
-  private func parseDate(_ dateString: String) -> Date? {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-    formatter.timeZone = TimeZone.current
-    return formatter.date(from: dateString)
-  }
-
-  private func formatDate(_ date: Date) -> String {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-    formatter.timeZone = TimeZone.current
-    return formatter.string(from: date)
-  }
-
-  private func createErrorOutput(error: Error) -> GeneratedContent {
-    return GeneratedContent(properties: [
-      "status": "error",
-      "error": error.localizedDescription,
-      "message": "Failed to perform calendar operation"
-    ])
+  static func formatEventQueryResults(_ events: [CalendarEventRecord]) -> String {
+    CalendarReadTool.formatEventQueryResults(events)
   }
 }
 
-struct CalendarEventSummary: Sendable {
-  let id: String
-  let title: String
-  let startDate: Date
-  let endDate: Date
-  let location: String?
-  let calendarTitle: String
-  let notes: String?
-
-  init(
-    id: String,
-    title: String,
-    startDate: Date,
-    endDate: Date,
-    location: String? = nil,
-    calendarTitle: String,
-    notes: String? = nil
-  ) {
-    self.id = id
-    self.title = title
-    self.startDate = startDate
-    self.endDate = endDate
-    self.location = location
-    self.calendarTitle = calendarTitle
-    self.notes = notes
-  }
-
-  init(event: EKEvent) {
-    self.id = event.eventIdentifier ?? ""
-    self.title = event.title ?? "Untitled"
-    self.startDate = event.startDate
-    self.endDate = event.endDate
-    self.location = event.location
-    self.calendarTitle = event.calendar?.title ?? "Unknown Calendar"
-    self.notes = event.notes
-  }
-}
-
-extension CalendarTool {
-  static func formatEventQueryResults(_ events: [CalendarEventSummary]) -> String {
-    var eventsDescription = ""
-
-    for (index, event) in events.enumerated() {
-      let dateFormatter = DateFormatter()
-      dateFormatter.dateStyle = .medium
-      dateFormatter.timeStyle = .short
-
-      let location = event.location != nil ? " at \(event.location!)" : ""
-
-      eventsDescription += "\(index + 1). \(event.title)\n"
-      eventsDescription += "   Event ID: \(event.id)\n"
-      eventsDescription +=
-        "   When: \(dateFormatter.string(from: event.startDate)) - \(dateFormatter.string(from: event.endDate))\n"
-      eventsDescription += "   Calendar: \(event.calendarTitle)\(location)\n"
-      if let notes = event.notes, !notes.isEmpty {
-        eventsDescription += "   Notes: \(notes.prefix(50))...\n"
-      }
-      eventsDescription += "\n"
-    }
-
-    return eventsDescription
-  }
-}
-
-enum CalendarError: Error, LocalizedError {
+public enum CalendarToolError: Error, LocalizedError, Sendable {
   case accessDenied
   case invalidAction
+  case invalidReadAction
+  case invalidMutationAction
   case missingTitle
   case invalidStartDate
   case invalidEndDate
-  case missingEventId
+  case endBeforeStart
+  case noChanges
+  case missingEventID
   case eventNotFound
 
-  var errorDescription: String? {
+  public var errorDescription: String? {
     switch self {
     case .accessDenied:
-      return "Access to calendar denied. Please grant permission in Settings."
+      "Access to Calendar was denied. Grant permission in Settings."
     case .invalidAction:
-      return "Invalid action. Use 'create', 'query', 'read', or 'update'."
+      "Invalid action. Use 'create', 'query', 'read', or 'update'."
+    case .invalidReadAction:
+      "Invalid read action. Use 'query' or 'read'."
+    case .invalidMutationAction:
+      "Invalid mutation action. Use 'create' or 'update'."
     case .missingTitle:
-      return "Title is required to create an event."
+      "Title is required to create an event."
     case .invalidStartDate:
-      return "Invalid start date format. Use YYYY-MM-DD HH:mm:ss"
+      "Invalid start date format. Use YYYY-MM-DD HH:mm:ss."
     case .invalidEndDate:
-      return "Invalid end date format. Use YYYY-MM-DD HH:mm:ss"
-    case .missingEventId:
-      return "Event ID is required."
+      "Invalid end date format. Use YYYY-MM-DD HH:mm:ss."
+    case .endBeforeStart:
+      "The event end date cannot be earlier than its start date."
+    case .noChanges:
+      "At least one event field is required for an update."
+    case .missingEventID:
+      "Event ID is required."
     case .eventNotFound:
-      return "Event not found with the provided ID."
+      "Event not found with the provided ID."
     }
   }
 }
+
+private enum CalendarToolDateFormatter {
+  static func date(from value: String) -> Date? {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    formatter.timeZone = .current
+    return formatter.date(from: value)
+  }
+
+  static func string(from date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+    formatter.timeZone = .current
+    return formatter.string(from: date)
+  }
+}
+
+typealias CalendarEventSummary = CalendarEventRecord
+typealias CalendarError = CalendarToolError

--- a/Sources/FoundationModelsTools/Tools/RemindersTool.swift
+++ b/Sources/FoundationModelsTools/Tools/RemindersTool.swift
@@ -1,81 +1,422 @@
-//
-//  RemindersTool.swift
-//  FoundationLab
-//
-//  Created by Rudrank Riyam on 6/17/25.
-//
-
-@preconcurrency import EventKit
 import Foundation
 import FoundationModels
 import FoundationModelsKit
 
-/// A tool for managing reminders using EventKit.
-///
-/// Use `RemindersTool` for create, read, update, complete, and delete operations
-/// for reminders. It integrates with the system Reminders app.
-///
-/// The following actions are supported:
-/// - `create`: Create a new reminder
-/// - `query`: Query reminders with optional filters
-/// - `complete`: Mark a reminder as completed
-/// - `update`: Update an existing reminder
-/// - `delete`: Delete a reminder
-///
-/// Query filters include: `all`, `incomplete`, `completed`, `today`, and `overdue`.
-///
-/// ```swift
-/// let session = LanguageModelSession(tools: [RemindersTool()])
-/// let response = try await session.respond(to: "Remind me to buy groceries tomorrow")
-/// ```
-///
-/// - Important: Requires Reminders entitlement, `NSRemindersUsageDescription` in Info.plist,
-///   and user permission at runtime.
-public struct RemindersTool: Tool {
+/// Read-only Reminders access. This tool cannot create, update, complete, or delete reminders.
+public struct RemindersReadTool: Tool {
+  public let name = "readReminders"
+  public let description = "Query reminders with an optional status or date filter"
 
-  /// The name of the tool, used for identification.
-  public let name = "manageReminders"
-  /// A brief description of the tool's functionality.
-  public let description =
-    "Create, read, update, complete, and query reminders from the Reminders app"
-
-  /// Arguments for reminder operations.
   @Generable
   public struct Arguments: RuntimeCompatibleGenerable {
-    /// The action to perform: "create", "query", "complete", "update", "delete"
-    @Guide(description: "The action to perform: 'create', 'query', 'complete', 'update', 'delete'")
+    @Guide(description: "Filter: 'all', 'incomplete', 'completed', 'today', or 'overdue'")
+    public var filter: String?
+
+    public init(filter: String? = nil) {
+      self.filter = filter
+    }
+  }
+
+  private let service: any RemindersReading
+  private let now: @Sendable () -> Date
+
+  public init(
+    service: any RemindersReading,
+    now: @escaping @Sendable () -> Date = Date.init
+  ) {
+    self.service = service
+    self.now = now
+  }
+
+  public func call(arguments: Arguments) async throws -> GeneratedContent {
+    let authorized: Bool
+    do {
+      authorized = try await service.requestRemindersReadAccess()
+    } catch {
+      throw RemindersToolError.accessDenied
+    }
+    guard authorized else {
+      throw RemindersToolError.accessDenied
+    }
+
+    let filter = Self.filter(from: arguments.filter)
+    var reminders = try await service.reminders(matching: filter, now: now())
+    reminders.sort(by: Self.sort)
+    let description = Self.formatReminderQueryResults(reminders)
+
+    return GeneratedContent(properties: [
+      "status": "success",
+      "filter": filter.rawValue,
+      "count": reminders.count,
+      "reminderIds": reminders.map(\.id),
+      "reminders": description.isEmpty
+        ? "No reminders found with filter '\(filter.rawValue)'"
+        : description.trimmingCharacters(in: .whitespacesAndNewlines),
+      "message": "Found \(reminders.count) reminder(s)"
+    ])
+  }
+
+  private static func filter(from value: String?) -> ReminderQueryFilter {
+    guard let value else { return .incomplete }
+    return ReminderQueryFilter(rawValue: value.lowercased()) ?? .incomplete
+  }
+
+  private static func sort(_ lhs: ReminderRecord, _ rhs: ReminderRecord) -> Bool {
+    if lhs.isCompleted != rhs.isCompleted {
+      return !lhs.isCompleted
+    }
+    if let lhsDate = lhs.dueDate, let rhsDate = rhs.dueDate {
+      return lhsDate < rhsDate
+    }
+    return lhs.dueDate != nil && rhs.dueDate == nil
+  }
+
+  static func formatReminderQueryResults(_ reminders: [ReminderRecord]) -> String {
+    reminders.enumerated().map { index, reminder in
+      var lines = [
+        "\(index + 1). \(reminder.isCompleted ? "[x]" : "[ ]") \(reminder.title)",
+        "   Reminder ID: \(reminder.id)",
+        "   List: \(reminder.listName)"
+      ]
+      if let dueDate = reminder.dueDate {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        lines.append("   Due: \(formatter.string(from: dueDate))")
+      }
+      if reminder.priority != .none {
+        lines.append("   Priority: \(reminder.priority.rawValue.capitalized)")
+      }
+      if let notes = reminder.notes, !notes.isEmpty {
+        lines.append("   Notes: \(notes.prefix(50))...")
+      }
+      return lines.joined(separator: "\n")
+    }.joined(separator: "\n\n")
+  }
+}
+
+/// Reminders mutations guarded by an app-owned confirmation provider.
+public struct RemindersMutationTool: Tool {
+  public let name = "mutateReminders"
+  public let description =
+    "Create, update, complete, or delete a reminder after host-app confirmation"
+
+  @Generable
+  public struct Arguments: RuntimeCompatibleGenerable {
+    @Guide(description: "The mutation action: 'create', 'complete', 'update', or 'delete'")
     public var action: String
 
-    /// Title of the reminder
-    @Guide(description: "Title of the reminder")
+    @Guide(description: "Reminder title")
     public var title: String?
 
-    /// Notes for the reminder
-    @Guide(description: "Notes for the reminder")
+    @Guide(description: "Reminder notes")
     public var notes: String?
 
-    /// Due date in format YYYY-MM-DD HH:mm:ss (24-hour format). Examples: '2025-01-15 17:00:00' for tomorrow at 5 PM
-    @Guide(
-      description:
-        "Due date in format YYYY-MM-DD HH:mm:ss (24-hour format). Examples: '2025-01-15 17:00:00' for tomorrow at 5 PM"
-    )
+    @Guide(description: "Due date in format YYYY-MM-DD HH:mm:ss, or 'none' when updating")
     public var dueDate: String?
 
-    /// Priority level: "none", "low", "medium", "high"
-    @Guide(description: "Priority level: 'none', 'low', 'medium', 'high'")
+    @Guide(description: "Priority: 'none', 'low', 'medium', or 'high'")
     public var priority: String?
 
-    /// List name (defaults to default reminders list)
-    @Guide(description: "List name (defaults to default reminders list)")
+    @Guide(description: "Reminder list name; the default list is used when omitted")
     public var listName: String?
 
-    /// Reminder identifier for updating/completing
-    @Guide(description: "Reminder identifier for updating/completing")
+    @Guide(description: "Reminder identifier for complete, update, or delete")
     public var reminderId: String?
 
-    /// Filter for querying: "all", "incomplete", "completed", "today", "overdue"
-    @Guide(description: "Filter for querying: 'all', 'incomplete', 'completed', 'today', 'overdue'")
-    public var filter: String?
+    public init(
+      action: String = "",
+      title: String? = nil,
+      notes: String? = nil,
+      dueDate: String? = nil,
+      priority: String? = nil,
+      listName: String? = nil,
+      reminderId: String? = nil
+    ) {
+      self.action = action
+      self.title = title
+      self.notes = notes
+      self.dueDate = dueDate
+      self.priority = priority
+      self.listName = listName
+      self.reminderId = reminderId
+    }
+  }
+
+  private enum PreparedMutation: Sendable {
+    case create(ReminderDraft)
+    case complete(id: String)
+    case update(id: String, changes: ReminderChanges)
+    case delete(id: String)
+  }
+
+  private let service: any RemindersMutating
+  private let executor: ToolMutationExecutor
+  private let now: @Sendable () -> Date
+
+  public init(
+    service: any RemindersMutating,
+    confirmation: any ToolMutationConfirming,
+    now: @escaping @Sendable () -> Date = Date.init
+  ) {
+    self.service = service
+    self.executor = ToolMutationExecutor(confirmer: confirmation, now: now)
+    self.now = now
+  }
+
+  init(
+    service: any RemindersMutating,
+    executor: ToolMutationExecutor,
+    now: @escaping @Sendable () -> Date
+  ) {
+    self.service = service
+    self.executor = executor
+    self.now = now
+  }
+
+  public func execute(
+    arguments: Arguments
+  ) async throws -> ToolMutationExecution<ReminderRecord> {
+    let prepared = try prepare(arguments)
+    let request = mutationRequest(for: prepared)
+    let service = service
+    let now = now
+
+    return try await executor.execute(
+      request,
+      resourceID: { $0.id },
+      operation: {
+        let authorized: Bool
+        do {
+          authorized = try await service.requestRemindersMutationAccess()
+        } catch {
+          throw ToolMutationOperationError(
+            failureDescription: error.localizedDescription,
+            commitState: .notAttempted
+          )
+        }
+
+        guard authorized else {
+          throw ToolMutationOperationError(
+            failureDescription: RemindersToolError.accessDenied.localizedDescription,
+            commitState: .notAttempted
+          )
+        }
+
+        do {
+          let record: ReminderRecord?
+          switch prepared {
+          case .create(let draft):
+            record = try await service.createReminder(draft)
+          case .complete(let id):
+            record = try await service.completeReminder(id: id, at: now())
+          case .update(let id, let changes):
+            record = try await service.updateReminder(id: id, changes: changes)
+          case .delete(let id):
+            record = try await service.deleteReminder(id: id)
+          }
+
+          guard let record else {
+            throw ToolMutationOperationError(
+              failureDescription: RemindersToolError.reminderNotFound.localizedDescription,
+              commitState: .notAttempted
+            )
+          }
+          return record
+        } catch let error as ToolMutationOperationError {
+          throw error
+        } catch {
+          throw ToolMutationOperationError(
+            failureDescription: error.localizedDescription,
+            commitState: .unknown
+          )
+        }
+      }
+    )
+  }
+
+  public func call(arguments: Arguments) async throws -> GeneratedContent {
+    let execution = try await execute(arguments: arguments)
+    let reminder = execution.value
+    let action = execution.receipt.request.action
+
+    return GeneratedContent(properties: [
+      "status": "success",
+      "message": Self.successMessage(for: action),
+      "receiptId": execution.receipt.request.id.uuidString,
+      "receiptStatus": execution.receipt.status.rawValue,
+      "commitState": execution.receipt.commitState.rawValue,
+      "reminderId": reminder.id,
+      "title": reminder.title,
+      "list": reminder.listName,
+      "dueDate": RemindersToolDateFormatter.string(from: reminder.dueDate),
+      "priority": reminder.priority.rawValue.capitalized,
+      "completedAt": RemindersToolDateFormatter.string(from: reminder.completionDate)
+    ])
+  }
+
+  private func prepare(_ arguments: Arguments) throws -> PreparedMutation {
+    switch arguments.action.lowercased() {
+    case "create":
+      guard let title = arguments.title?.trimmingCharacters(in: .whitespacesAndNewlines),
+        !title.isEmpty
+      else {
+        throw RemindersToolError.missingTitle
+      }
+      return .create(
+        ReminderDraft(
+          title: title,
+          notes: arguments.notes,
+          dueDate: try RemindersToolDateFormatter.optionalDate(from: arguments.dueDate),
+          priority: try priority(from: arguments.priority) ?? .none,
+          listName: arguments.listName
+        )
+      )
+    case "complete":
+      return .complete(id: try reminderID(from: arguments))
+    case "update":
+      guard
+        arguments.title != nil || arguments.notes != nil || arguments.dueDate != nil
+          || arguments.priority != nil
+      else {
+        throw RemindersToolError.noChanges
+      }
+      let clearDueDate = arguments.dueDate?.lowercased() == "none"
+      let dueDate =
+        clearDueDate
+        ? nil
+        : try RemindersToolDateFormatter.optionalDate(from: arguments.dueDate)
+      return .update(
+        id: try reminderID(from: arguments),
+        changes: ReminderChanges(
+          title: arguments.title,
+          notes: arguments.notes,
+          dueDate: dueDate,
+          clearDueDate: clearDueDate,
+          priority: try priority(from: arguments.priority)
+        )
+      )
+    case "delete":
+      return .delete(id: try reminderID(from: arguments))
+    default:
+      throw RemindersToolError.invalidMutationAction
+    }
+  }
+
+  private func reminderID(from arguments: Arguments) throws -> String {
+    guard let reminderID = arguments.reminderId, !reminderID.isEmpty else {
+      throw RemindersToolError.missingReminderID
+    }
+    return reminderID
+  }
+
+  private func priority(from value: String?) throws -> ReminderPriority? {
+    guard let value else { return nil }
+    guard let priority = ReminderPriority(rawValue: value.lowercased()) else {
+      throw RemindersToolError.invalidPriority
+    }
+    return priority
+  }
+
+  private func mutationRequest(for mutation: PreparedMutation) -> ToolMutationRequest {
+    switch mutation {
+    case .create(let draft):
+      ToolMutationRequest(
+        toolName: name,
+        action: "create",
+        summary: "Create reminder '\(draft.title)'",
+        details: mutationDetails(for: draft)
+      )
+    case .complete(let id):
+      ToolMutationRequest(
+        toolName: name,
+        action: "complete",
+        summary: "Mark reminder '\(id)' complete",
+        resourceID: id
+      )
+    case .update(let id, let changes):
+      ToolMutationRequest(
+        toolName: name,
+        action: "update",
+        summary: "Update reminder '\(changes.title ?? id)'",
+        details: mutationDetails(for: changes),
+        resourceID: id
+      )
+    case .delete(let id):
+      ToolMutationRequest(
+        toolName: name,
+        action: "delete",
+        summary: "Delete reminder '\(id)'",
+        resourceID: id,
+        isDestructive: true
+      )
+    }
+  }
+
+  private func mutationDetails(for draft: ReminderDraft) -> [ToolMutationDetail] {
+    [
+      ToolMutationDetail(label: "Title", value: draft.title),
+      optionalDetail(label: "Notes", value: draft.notes),
+      draft.dueDate.map {
+        ToolMutationDetail(label: "Due", value: RemindersToolDateFormatter.string(from: $0))
+      },
+      ToolMutationDetail(label: "Priority", value: draft.priority.rawValue),
+      optionalDetail(label: "List", value: draft.listName)
+    ].compactMap { $0 }
+  }
+
+  private func mutationDetails(for changes: ReminderChanges) -> [ToolMutationDetail] {
+    [
+      optionalDetail(label: "Title", value: changes.title),
+      optionalDetail(label: "Notes", value: changes.notes),
+      changes.clearDueDate
+        ? ToolMutationDetail(label: "Due", value: "none")
+        : changes.dueDate.map {
+          ToolMutationDetail(label: "Due", value: RemindersToolDateFormatter.string(from: $0))
+        },
+      changes.priority.map {
+        ToolMutationDetail(label: "Priority", value: $0.rawValue)
+      }
+    ].compactMap { $0 }
+  }
+
+  private func optionalDetail(label: String, value: String?) -> ToolMutationDetail? {
+    value.map { ToolMutationDetail(label: label, value: $0) }
+  }
+
+  private static func successMessage(for action: String) -> String {
+    switch action {
+    case "create": "Reminder created successfully"
+    case "complete": "Reminder completed successfully"
+    case "update": "Reminder updated successfully"
+    case "delete": "Reminder deleted successfully"
+    default: "Reminder mutation committed successfully"
+    }
+  }
+}
+
+/// Backward-compatible combined Reminders tool. New code should register split tools.
+@available(
+  *,
+  deprecated,
+  message:
+    "Use RemindersReadTool and RemindersMutationTool so mutations require explicit confirmation."
+)
+public struct RemindersTool: Tool {
+  public let name = "manageReminders"
+  public let description = "Read reminders; mutations require host-app confirmation"
+
+  @Generable
+  public struct Arguments: RuntimeCompatibleGenerable {
+    @Guide(description: "The action: 'create', 'query', 'complete', 'update', or 'delete'")
+    public var action: String
+    @Guide(description: "Reminder title") public var title: String?
+    @Guide(description: "Reminder notes") public var notes: String?
+    @Guide(description: "Due date") public var dueDate: String?
+    @Guide(description: "Priority") public var priority: String?
+    @Guide(description: "List name") public var listName: String?
+    @Guide(description: "Reminder identifier") public var reminderId: String?
+    @Guide(description: "Query filter") public var filter: String?
 
     public init(
       action: String = "",
@@ -98,454 +439,152 @@ public struct RemindersTool: Tool {
     }
   }
 
-  nonisolated(unsafe) private let eventStore = EKEventStore()
+  private let readTool: RemindersReadTool
+  private let mutationTool: RemindersMutationTool?
 
-  public init() {}
+  public init() {
+    let service = EventKitRemindersService()
+    self.readTool = RemindersReadTool(service: service)
+    self.mutationTool = nil
+  }
+
+  public init(
+    readService: any RemindersReading,
+    mutationService: any RemindersMutating,
+    confirmation: any ToolMutationConfirming
+  ) {
+    self.readTool = RemindersReadTool(service: readService)
+    self.mutationTool = RemindersMutationTool(
+      service: mutationService,
+      confirmation: confirmation
+    )
+  }
+
+  public init(confirmation: any ToolMutationConfirming) {
+    let service = EventKitRemindersService()
+    self.init(
+      readService: service,
+      mutationService: service,
+      confirmation: confirmation
+    )
+  }
 
   public func call(arguments: Arguments) async throws -> some PromptRepresentable {
-    // Request access if needed
-    let authorized = await requestAccess()
-    guard authorized else {
-      return createErrorOutput(error: RemindersError.accessDenied)
-    }
-
     switch arguments.action.lowercased() {
-    case "create":
-      return try createReminder(arguments: arguments)
     case "query":
-      return await queryReminders(arguments: arguments)
-    case "complete":
-      return try completeReminder(reminderId: arguments.reminderId)
-    case "update":
-      return try updateReminder(arguments: arguments)
-    case "delete":
-      return try deleteReminder(reminderId: arguments.reminderId)
-    default:
-      return createErrorOutput(error: RemindersError.invalidAction)
-    }
-  }
-
-  private func requestAccess() async -> Bool {
-    do {
-      if #available(macOS 14.0, iOS 17.0, *) {
-        return try await eventStore.requestFullAccessToReminders()
-      } else {
-        return try await eventStore.requestAccess(to: .reminder)
-      }
-    } catch {
-      return false
-    }
-  }
-
-  private func createReminder(arguments: Arguments) throws -> GeneratedContent {
-    guard let title = arguments.title, !title.isEmpty else {
-      return createErrorOutput(error: RemindersError.missingTitle)
-    }
-
-    let reminder = EKReminder(eventStore: eventStore)
-    reminder.title = title
-
-    if let notes = arguments.notes {
-      reminder.notes = notes
-    }
-
-    if let dueDateString = arguments.dueDate,
-      let dueDate = parseDate(dueDateString) {
-      reminder.dueDateComponents = Calendar.current.dateComponents(
-        [.year, .month, .day, .hour, .minute],
-        from: dueDate
-      )
-    }
-
-    // Set priority
-    if let priorityString = arguments.priority {
-      switch priorityString.lowercased() {
-      case "high":
-        reminder.priority = 1
-      case "medium":
-        reminder.priority = 5
-      case "low":
-        reminder.priority = 9
-      default:
-        reminder.priority = 0  // none
-      }
-    }
-
-    // Set calendar (list)
-    if let listName = arguments.listName {
-      let calendars = eventStore.calendars(for: .reminder)
-      if let calendar = calendars.first(where: { $0.title == listName }) {
-        reminder.calendar = calendar
-      } else {
-        reminder.calendar = eventStore.defaultCalendarForNewReminders()
-      }
-    } else {
-      reminder.calendar = eventStore.defaultCalendarForNewReminders()
-    }
-
-    do {
-      try eventStore.save(reminder, commit: true)
-
-      return GeneratedContent(properties: [
-        "status": "success",
-        "message": "Reminder created successfully",
-        "reminderId": reminder.calendarItemIdentifier,
-        "title": reminder.title ?? "",
-        "list": reminder.calendar?.title ?? "",
-        "dueDate": formatDateComponents(reminder.dueDateComponents),
-        "priority": Self.getPriorityString(reminder.priority)
-      ])
-    } catch {
-      return createErrorOutput(error: error)
-    }
-  }
-
-  private func queryReminders(arguments: Arguments) async -> GeneratedContent {
-    let calendars = eventStore.calendars(for: .reminder)
-    var predicate: NSPredicate
-
-    let filter = arguments.filter?.lowercased() ?? "incomplete"
-
-    switch filter {
-    case "all":
-      predicate = eventStore.predicateForReminders(in: calendars)
-    case "completed":
-      predicate = eventStore.predicateForCompletedReminders(
-        withCompletionDateStarting: nil, ending: nil, calendars: calendars)
-    case "today":
-      let startOfDay = Calendar.current.startOfDay(for: Date())
-      let endOfDay = Calendar.current.date(byAdding: .day, value: 1, to: startOfDay)!
-      predicate = eventStore.predicateForIncompleteReminders(
-        withDueDateStarting: startOfDay, ending: endOfDay, calendars: calendars)
-    case "overdue":
-      predicate = eventStore.predicateForIncompleteReminders(
-        withDueDateStarting: nil, ending: Date(), calendars: calendars)
-    default:  // "incomplete"
-      predicate = eventStore.predicateForIncompleteReminders(
-        withDueDateStarting: nil, ending: nil, calendars: calendars)
-    }
-
-    var reminders = await fetchReminders(matching: predicate)
-
-    // Sort reminders
-    reminders.sort { reminder1, reminder2 in
-      // First by completion status
-      if reminder1.isCompleted != reminder2.isCompleted {
-        return !reminder1.isCompleted
-      }
-
-      // Then by due date
-      if let date1 = reminder1.dueDate,
-        let date2 = reminder2.dueDate {
-        return date1 < date2
-      }
-
-      // Reminders with due dates come before those without
-      if reminder1.dueDate != nil && reminder2.dueDate == nil {
-        return true
-      }
-
-      return false
-    }
-
-    var remindersDescription = Self.formatReminderQueryResults(reminders)
-
-    if remindersDescription.isEmpty {
-      remindersDescription = "No reminders found with filter '\(filter)'"
-    }
-
-    return GeneratedContent(properties: [
-      "status": "success",
-      "filter": filter,
-      "count": reminders.count,
-      "reminderIds": reminders.map(\.id),
-      "reminders": remindersDescription.trimmingCharacters(in: .whitespacesAndNewlines),
-      "message": "Found \(reminders.count) reminder(s)"
-    ])
-  }
-
-  private func fetchReminders(matching predicate: NSPredicate) async -> [ReminderSnapshot] {
-    await withCheckedContinuation { continuation in
-      eventStore.fetchReminders(matching: predicate) { fetchedReminders in
-        let snapshots = fetchedReminders?.map(ReminderSnapshot.init) ?? []
-        continuation.resume(returning: snapshots)
-      }
-    }
-  }
-
-  private func completeReminder(reminderId: String?) throws -> GeneratedContent {
-    guard let id = reminderId else {
-      return createErrorOutput(error: RemindersError.missingReminderId)
-    }
-
-    guard let reminder = eventStore.calendarItem(withIdentifier: id) as? EKReminder else {
-      return createErrorOutput(error: RemindersError.reminderNotFound)
-    }
-
-    reminder.isCompleted = true
-    reminder.completionDate = Date()
-
-    do {
-      try eventStore.save(reminder, commit: true)
-
-      return GeneratedContent(properties: [
-        "status": "success",
-        "message": "Reminder completed successfully",
-        "reminderId": reminder.calendarItemIdentifier,
-        "title": reminder.title ?? "",
-        "completedAt": formatDate(Date())
-      ])
-    } catch {
-      return createErrorOutput(error: error)
-    }
-  }
-
-  private func updateReminder(arguments: Arguments) throws -> GeneratedContent {
-    guard let reminderId = arguments.reminderId else {
-      return createErrorOutput(error: RemindersError.missingReminderId)
-    }
-
-    guard let reminder = eventStore.calendarItem(withIdentifier: reminderId) as? EKReminder else {
-      return createErrorOutput(error: RemindersError.reminderNotFound)
-    }
-
-    // Update fields if provided
-    if let title = arguments.title {
-      reminder.title = title
-    }
-
-    if let notes = arguments.notes {
-      reminder.notes = notes
-    }
-
-    if let dueDateString = arguments.dueDate {
-      if let dueDate = parseDate(dueDateString) {
-        reminder.dueDateComponents = Calendar.current.dateComponents(
-          [.year, .month, .day, .hour, .minute],
-          from: dueDate
+      return try await readTool.call(
+        arguments: RemindersReadTool.Arguments(filter: arguments.filter))
+    case "create", "complete", "update", "delete":
+      guard let mutationTool else {
+        throw ToolMutationExecutionError.confirmationRequired(
+          for: ToolMutationRequest(
+            toolName: "mutateReminders",
+            action: arguments.action.lowercased(),
+            summary: "Reminders mutation requested by deprecated RemindersTool",
+            resourceID: arguments.reminderId,
+            isDestructive: arguments.action.lowercased() == "delete"
+          )
         )
-      } else if dueDateString.lowercased() == "none" {
-        reminder.dueDateComponents = nil
       }
-    }
-
-    if let priorityString = arguments.priority {
-      switch priorityString.lowercased() {
-      case "high":
-        reminder.priority = 1
-      case "medium":
-        reminder.priority = 5
-      case "low":
-        reminder.priority = 9
-      default:
-        reminder.priority = 0
-      }
-    }
-
-    do {
-      try eventStore.save(reminder, commit: true)
-
-      return GeneratedContent(properties: [
-        "status": "success",
-        "message": "Reminder updated successfully",
-        "reminderId": reminder.calendarItemIdentifier,
-        "title": reminder.title ?? "",
-        "list": reminder.calendar?.title ?? "",
-        "dueDate": formatDateComponents(reminder.dueDateComponents),
-        "priority": Self.getPriorityString(reminder.priority)
-      ])
-    } catch {
-      return createErrorOutput(error: error)
+      return try await mutationTool.call(
+        arguments: RemindersMutationTool.Arguments(
+          action: arguments.action,
+          title: arguments.title,
+          notes: arguments.notes,
+          dueDate: arguments.dueDate,
+          priority: arguments.priority,
+          listName: arguments.listName,
+          reminderId: arguments.reminderId
+        )
+      )
+    default:
+      throw RemindersToolError.invalidAction
     }
   }
 
-  private func deleteReminder(reminderId: String?) throws -> GeneratedContent {
-    guard let id = reminderId else {
-      return createErrorOutput(error: RemindersError.missingReminderId)
-    }
+  static func formatReminderQueryResults(_ reminders: [ReminderRecord]) -> String {
+    RemindersReadTool.formatReminderQueryResults(reminders)
+  }
+}
 
-    guard let reminder = eventStore.calendarItem(withIdentifier: id) as? EKReminder else {
-      return createErrorOutput(error: RemindersError.reminderNotFound)
-    }
+public enum RemindersToolError: Error, LocalizedError, Sendable {
+  case accessDenied
+  case invalidAction
+  case invalidMutationAction
+  case invalidPriority
+  case invalidDueDate
+  case noChanges
+  case missingTitle
+  case missingReminderID
+  case reminderNotFound
 
-    let title = reminder.title ?? "Untitled"
-
-    do {
-      try eventStore.remove(reminder, commit: true)
-
-      return GeneratedContent(properties: [
-        "status": "success",
-        "message": "Reminder deleted successfully",
-        "deletedTitle": title
-      ])
-    } catch {
-      return createErrorOutput(error: error)
+  public var errorDescription: String? {
+    switch self {
+    case .accessDenied:
+      "Access to Reminders was denied. Grant permission in Settings."
+    case .invalidAction:
+      "Invalid action. Use 'create', 'query', 'complete', 'update', or 'delete'."
+    case .invalidMutationAction:
+      "Invalid mutation action. Use 'create', 'complete', 'update', or 'delete'."
+    case .invalidPriority:
+      "Invalid priority. Use 'none', 'low', 'medium', or 'high'."
+    case .invalidDueDate:
+      "Invalid due date. Use YYYY-MM-DD HH:mm:ss or an ISO 8601 date."
+    case .noChanges:
+      "At least one reminder field is required for an update."
+    case .missingTitle:
+      "Title is required to create a reminder."
+    case .missingReminderID:
+      "Reminder ID is required."
+    case .reminderNotFound:
+      "Reminder not found with the provided ID."
     }
   }
+}
 
-  private func parseDate(_ dateString: String) -> Date? {
+private enum RemindersToolDateFormatter {
+  static func optionalDate(from value: String?) throws -> Date? {
+    guard let value else { return nil }
+    if value.lowercased() == "none" {
+      return nil
+    }
+    guard let date = date(from: value) else {
+      throw RemindersToolError.invalidDueDate
+    }
+    return date
+  }
+
+  static func date(from value: String) -> Date? {
     let formatter = DateFormatter()
-    formatter.timeZone = TimeZone.current
+    formatter.timeZone = .current
 
-    // Try multiple date formats to be more flexible
-    let formats = [
-      "yyyy-MM-dd HH:mm:ss",  // Primary format: 2025-01-15 17:00:00
-      "yyyy-MM-dd HH:mm",  // Without seconds: 2025-01-15 17:00
-      "yyyy-MM-dd",  // Date only: 2025-01-15 (defaults to start of day)
-      "MM/dd/yyyy HH:mm:ss",  // US format: 01/15/2025 17:00:00
-      "MM/dd/yyyy HH:mm",  // US format without seconds: 01/15/2025 17:00
-      "MM/dd/yyyy"  // US date only: 01/15/2025
-    ]
-
-    for format in formats {
+    for format in [
+      "yyyy-MM-dd HH:mm:ss",
+      "yyyy-MM-dd HH:mm",
+      "yyyy-MM-dd",
+      "MM/dd/yyyy HH:mm:ss",
+      "MM/dd/yyyy HH:mm",
+      "MM/dd/yyyy"
+    ] {
       formatter.dateFormat = format
-      if let date = formatter.date(from: dateString) {
+      if let date = formatter.date(from: value) {
         return date
       }
     }
 
-    // If no format worked, try ISO 8601 formatter as fallback
     let isoFormatter = ISO8601DateFormatter()
-    isoFormatter.timeZone = TimeZone.current
-    return isoFormatter.date(from: dateString)
+    isoFormatter.timeZone = .current
+    return isoFormatter.date(from: value)
   }
 
-  private func formatDate(_ date: Date) -> String {
+  static func string(from date: Date?) -> String {
+    guard let date else { return "" }
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-    formatter.timeZone = TimeZone.current
+    formatter.timeZone = .current
     return formatter.string(from: date)
   }
-
-  private func formatDateComponents(_ components: DateComponents?) -> String {
-    guard let components = components,
-      let date = Calendar.current.date(from: components)
-    else {
-      return ""
-    }
-
-    let formatter = DateFormatter()
-    formatter.dateStyle = .medium
-    formatter.timeStyle = .short
-    return formatter.string(from: date)
-  }
-
-  private static func formatReminderDueDate(_ date: Date?) -> String {
-    guard let date else { return "" }
-
-    let formatter = DateFormatter()
-    formatter.dateStyle = .medium
-    formatter.timeStyle = .short
-    return formatter.string(from: date)
-  }
-
-  private static func getPriorityString(_ priority: Int) -> String {
-    switch priority {
-    case 1...3:
-      return "High"
-    case 4...6:
-      return "Medium"
-    case 7...9:
-      return "Low"
-    default:
-      return "None"
-    }
-  }
-
-  private func createErrorOutput(error: Error) -> GeneratedContent {
-    return GeneratedContent(properties: [
-      "status": "error",
-      "error": error.localizedDescription,
-      "message": "Failed to perform reminder operation"
-    ])
-  }
 }
 
-struct ReminderSnapshot: Sendable {
-  let id: String
-  let title: String
-  let listName: String
-  let dueDate: Date?
-  let priority: Int
-  let notes: String?
-  let isCompleted: Bool
-
-  init(reminder: EKReminder) {
-    self.id = reminder.calendarItemIdentifier
-    self.title = reminder.title ?? "Untitled"
-    self.listName = reminder.calendar?.title ?? "Unknown List"
-    self.dueDate = reminder.dueDateComponents?.date
-    self.priority = reminder.priority
-    self.notes = reminder.notes
-    self.isCompleted = reminder.isCompleted
-  }
-
-  init(
-    id: String,
-    title: String,
-    listName: String,
-    dueDate: Date? = nil,
-    priority: Int = 0,
-    notes: String? = nil,
-    isCompleted: Bool = false
-  ) {
-    self.id = id
-    self.title = title
-    self.listName = listName
-    self.dueDate = dueDate
-    self.priority = priority
-    self.notes = notes
-    self.isCompleted = isCompleted
-  }
-}
-
-extension RemindersTool {
-  static func formatReminderQueryResults(_ reminders: [ReminderSnapshot]) -> String {
-    var remindersDescription = ""
-
-    for (index, reminder) in reminders.enumerated() {
-      let completed = reminder.isCompleted ? "[x]" : "[ ]"
-      let priority = Self.getPriorityString(reminder.priority)
-      let dueDate = Self.formatReminderDueDate(reminder.dueDate)
-
-      remindersDescription += "\(index + 1). \(completed) \(reminder.title)\n"
-      remindersDescription += "   Reminder ID: \(reminder.id)\n"
-      remindersDescription += "   List: \(reminder.listName)\n"
-      if !dueDate.isEmpty {
-        remindersDescription += "   Due: \(dueDate)\n"
-      }
-      if priority != "None" {
-        remindersDescription += "   Priority: \(priority)\n"
-      }
-      if let notes = reminder.notes, !notes.isEmpty {
-        remindersDescription += "   Notes: \(notes.prefix(50))...\n"
-      }
-      remindersDescription += "\n"
-    }
-
-    return remindersDescription
-  }
-}
-
-enum RemindersError: Error, LocalizedError {
-  case accessDenied
-  case invalidAction
-  case missingTitle
-  case missingReminderId
-  case reminderNotFound
-
-  var errorDescription: String? {
-    switch self {
-    case .accessDenied:
-      return "Access to reminders denied. Please grant permission in Settings."
-    case .invalidAction:
-      return "Invalid action. Use 'create', 'query', 'complete', 'update', or 'delete'."
-    case .missingTitle:
-      return "Title is required to create a reminder."
-    case .missingReminderId:
-      return "Reminder ID is required."
-    case .reminderNotFound:
-      return "Reminder not found with the provided ID."
-    }
-  }
-}
+typealias ReminderSnapshot = ReminderRecord
+typealias RemindersError = RemindersToolError

--- a/Sources/FoundationModelsToolsTestSupport/FoundationModelsToolsFixtures.swift
+++ b/Sources/FoundationModelsToolsTestSupport/FoundationModelsToolsFixtures.swift
@@ -1,0 +1,354 @@
+import Foundation
+import FoundationModelsTools
+
+/// Deterministic values for downstream tool tests and previews.
+public enum FoundationModelsToolsFixtures {
+  public static let date = Date(timeIntervalSince1970: 1_830_816_000)
+
+  public static let calendarEvent = CalendarEventRecord(
+    id: "calendar-event-1",
+    title: "Design review",
+    startDate: date,
+    endDate: date.addingTimeInterval(3_600),
+    location: "Studio",
+    calendarTitle: "Work",
+    notes: "Review the release candidate"
+  )
+
+  public static let reminder = ReminderRecord(
+    id: "reminder-1",
+    title: "Ship the release",
+    listName: "Work",
+    dueDate: date,
+    priority: .high,
+    notes: "Verify the tag first"
+  )
+}
+
+public enum ToolMutationConfirmationFixture: Sendable {
+  case approve
+  case deny(reason: String? = nil)
+  case fail(message: String)
+}
+
+public struct ToolMutationConfirmationFixtureError: Error, LocalizedError, Sendable {
+  public let message: String
+
+  public init(message: String) {
+    self.message = message
+  }
+
+  public var errorDescription: String? {
+    message
+  }
+}
+
+/// A confirmer that returns scripted decisions and records every request.
+public actor ScriptedToolMutationConfirmer: ToolMutationConfirming {
+  private var outcomes: [ToolMutationConfirmationFixture]
+  private var receivedRequests: [ToolMutationRequest] = []
+
+  public init(_ outcomes: [ToolMutationConfirmationFixture]) {
+    self.outcomes = outcomes
+  }
+
+  public init(_ outcome: ToolMutationConfirmationFixture) {
+    self.init([outcome])
+  }
+
+  public func confirmation(for request: ToolMutationRequest) throws -> ToolMutationDecision {
+    receivedRequests.append(request)
+    let outcome =
+      outcomes.isEmpty ? .deny(reason: "No scripted confirmation remains.") : outcomes.removeFirst()
+
+    switch outcome {
+    case .approve:
+      return .approved()
+    case .deny(let reason):
+      return .denied(reason: reason)
+    case .fail(let message):
+      throw ToolMutationConfirmationFixtureError(message: message)
+    }
+  }
+
+  public func requests() -> [ToolMutationRequest] {
+    receivedRequests
+  }
+}
+
+/// An in-memory Calendar service with access controls and injectable mutation failure.
+public actor InMemoryCalendarService: CalendarReading, CalendarMutating {
+  private var records: [String: CalendarEventRecord]
+  private let readAccess: Bool
+  private let mutationAccess: Bool
+  private let readAccessFailure: String?
+  private let mutationAccessFailure: String?
+  private var nextMutationFailure: ToolMutationOperationError?
+  private var mutationCalls = 0
+  private var readCalls = 0
+  private var generatedID = 0
+
+  public init(
+    events: [CalendarEventRecord] = [],
+    readAccess: Bool = true,
+    mutationAccess: Bool = true,
+    readAccessFailure: String? = nil,
+    mutationAccessFailure: String? = nil
+  ) {
+    self.records = Dictionary(uniqueKeysWithValues: events.map { ($0.id, $0) })
+    self.readAccess = readAccess
+    self.mutationAccess = mutationAccess
+    self.readAccessFailure = readAccessFailure
+    self.mutationAccessFailure = mutationAccessFailure
+  }
+
+  public func requestCalendarReadAccess() async throws -> Bool {
+    if let readAccessFailure {
+      throw ToolMutationConfirmationFixtureError(message: readAccessFailure)
+    }
+    return readAccess
+  }
+
+  public func requestCalendarMutationAccess() async throws -> Bool {
+    if let mutationAccessFailure {
+      throw ToolMutationConfirmationFixtureError(message: mutationAccessFailure)
+    }
+    return mutationAccess
+  }
+
+  public func calendarEvents(
+    from startDate: Date,
+    to endDate: Date
+  ) async throws -> [CalendarEventRecord] {
+    readCalls += 1
+    return records.values
+      .filter { $0.startDate < endDate && $0.endDate >= startDate }
+      .sorted { $0.startDate < $1.startDate }
+  }
+
+  public func calendarEvent(id: String) async throws -> CalendarEventRecord? {
+    readCalls += 1
+    return records[id]
+  }
+
+  public func createCalendarEvent(_ draft: CalendarEventDraft) async throws -> CalendarEventRecord {
+    mutationCalls += 1
+    try throwFailureIfNeeded()
+    guard draft.endDate >= draft.startDate else {
+      throw ToolMutationOperationError(
+        failureDescription: CalendarToolError.endBeforeStart.localizedDescription,
+        commitState: .notAttempted
+      )
+    }
+    generatedID += 1
+    let record = CalendarEventRecord(
+      id: "calendar-generated-\(generatedID)",
+      title: draft.title,
+      startDate: draft.startDate,
+      endDate: draft.endDate,
+      location: draft.location,
+      calendarTitle: draft.calendarName ?? "Default",
+      notes: draft.notes
+    )
+    records[record.id] = record
+    return record
+  }
+
+  public func updateCalendarEvent(
+    id: String,
+    changes: CalendarEventChanges
+  ) async throws -> CalendarEventRecord? {
+    mutationCalls += 1
+    try throwFailureIfNeeded()
+    guard let existing = records[id] else { return nil }
+    let record = CalendarEventRecord(
+      id: existing.id,
+      title: changes.title ?? existing.title,
+      startDate: changes.startDate ?? existing.startDate,
+      endDate: changes.endDate ?? existing.endDate,
+      location: changes.location ?? existing.location,
+      calendarTitle: existing.calendarTitle,
+      notes: changes.notes ?? existing.notes,
+      isAllDay: existing.isAllDay,
+      url: existing.url,
+      hasAlarms: existing.hasAlarms
+    )
+    guard record.endDate >= record.startDate else {
+      throw ToolMutationOperationError(
+        failureDescription: CalendarToolError.endBeforeStart.localizedDescription,
+        commitState: .notAttempted
+      )
+    }
+    records[id] = record
+    return record
+  }
+
+  public func setNextMutationFailure(_ failure: ToolMutationOperationError?) {
+    nextMutationFailure = failure
+  }
+
+  public func mutationCallCount() -> Int {
+    mutationCalls
+  }
+
+  public func readCallCount() -> Int {
+    readCalls
+  }
+
+  public func events() -> [CalendarEventRecord] {
+    records.values.sorted { $0.id < $1.id }
+  }
+
+  private func throwFailureIfNeeded() throws {
+    guard let failure = nextMutationFailure else { return }
+    nextMutationFailure = nil
+    throw failure
+  }
+}
+
+/// An in-memory Reminders service with access controls and injectable mutation failure.
+public actor InMemoryRemindersService: RemindersReading, RemindersMutating {
+  private var records: [String: ReminderRecord]
+  private let readAccess: Bool
+  private let mutationAccess: Bool
+  private let readAccessFailure: String?
+  private let mutationAccessFailure: String?
+  private var nextMutationFailure: ToolMutationOperationError?
+  private var mutationCalls = 0
+  private var readCalls = 0
+  private var generatedID = 0
+
+  public init(
+    reminders: [ReminderRecord] = [],
+    readAccess: Bool = true,
+    mutationAccess: Bool = true,
+    readAccessFailure: String? = nil,
+    mutationAccessFailure: String? = nil
+  ) {
+    self.records = Dictionary(uniqueKeysWithValues: reminders.map { ($0.id, $0) })
+    self.readAccess = readAccess
+    self.mutationAccess = mutationAccess
+    self.readAccessFailure = readAccessFailure
+    self.mutationAccessFailure = mutationAccessFailure
+  }
+
+  public func requestRemindersReadAccess() async throws -> Bool {
+    if let readAccessFailure {
+      throw ToolMutationConfirmationFixtureError(message: readAccessFailure)
+    }
+    return readAccess
+  }
+
+  public func requestRemindersMutationAccess() async throws -> Bool {
+    if let mutationAccessFailure {
+      throw ToolMutationConfirmationFixtureError(message: mutationAccessFailure)
+    }
+    return mutationAccess
+  }
+
+  public func reminders(
+    matching filter: ReminderQueryFilter,
+    now: Date
+  ) async throws -> [ReminderRecord] {
+    readCalls += 1
+    return records.values.filter { reminder in
+      switch filter {
+      case .all:
+        true
+      case .incomplete:
+        !reminder.isCompleted
+      case .completed:
+        reminder.isCompleted
+      case .today:
+        !reminder.isCompleted
+          && (reminder.dueDate.map { Calendar.current.isDate($0, inSameDayAs: now) } ?? false)
+      case .overdue:
+        !reminder.isCompleted && (reminder.dueDate.map { $0 < now } ?? false)
+      }
+    }
+  }
+
+  public func createReminder(_ draft: ReminderDraft) async throws -> ReminderRecord {
+    mutationCalls += 1
+    try throwFailureIfNeeded()
+    generatedID += 1
+    let record = ReminderRecord(
+      id: "reminder-generated-\(generatedID)",
+      title: draft.title,
+      listName: draft.listName ?? "Default",
+      dueDate: draft.dueDate,
+      priority: draft.priority,
+      notes: draft.notes
+    )
+    records[record.id] = record
+    return record
+  }
+
+  public func completeReminder(id: String, at date: Date) async throws -> ReminderRecord? {
+    mutationCalls += 1
+    try throwFailureIfNeeded()
+    guard let existing = records[id] else { return nil }
+    let record = ReminderRecord(
+      id: existing.id,
+      title: existing.title,
+      listName: existing.listName,
+      dueDate: existing.dueDate,
+      priority: existing.priority,
+      notes: existing.notes,
+      isCompleted: true,
+      completionDate: date
+    )
+    records[id] = record
+    return record
+  }
+
+  public func updateReminder(
+    id: String,
+    changes: ReminderChanges
+  ) async throws -> ReminderRecord? {
+    mutationCalls += 1
+    try throwFailureIfNeeded()
+    guard let existing = records[id] else { return nil }
+    let dueDate = changes.clearDueDate ? nil : changes.dueDate ?? existing.dueDate
+    let record = ReminderRecord(
+      id: existing.id,
+      title: changes.title ?? existing.title,
+      listName: existing.listName,
+      dueDate: dueDate,
+      priority: changes.priority ?? existing.priority,
+      notes: changes.notes ?? existing.notes,
+      isCompleted: existing.isCompleted,
+      completionDate: existing.completionDate
+    )
+    records[id] = record
+    return record
+  }
+
+  public func deleteReminder(id: String) async throws -> ReminderRecord? {
+    mutationCalls += 1
+    try throwFailureIfNeeded()
+    return records.removeValue(forKey: id)
+  }
+
+  public func setNextMutationFailure(_ failure: ToolMutationOperationError?) {
+    nextMutationFailure = failure
+  }
+
+  public func mutationCallCount() -> Int {
+    mutationCalls
+  }
+
+  public func readCallCount() -> Int {
+    readCalls
+  }
+
+  public func reminders() -> [ReminderRecord] {
+    records.values.sorted { $0.id < $1.id }
+  }
+
+  private func throwFailureIfNeeded() throws {
+    guard let failure = nextMutationFailure else { return }
+    nextMutationFailure = nil
+    throw failure
+  }
+}

--- a/Tests/FoundationModelsToolsTests/ToolMutationSafetyTests.swift
+++ b/Tests/FoundationModelsToolsTests/ToolMutationSafetyTests.swift
@@ -1,0 +1,460 @@
+import Foundation
+import FoundationModelsTools
+import FoundationModelsToolsTestSupport
+import Testing
+
+@Suite("Tool Mutation Safety")
+struct ToolMutationSafetyTests {
+  private let fixedDate = FoundationModelsToolsFixtures.date
+
+  @Test("Calendar reads do not require mutation confirmation")
+  func calendarReadDoesNotRequireConfirmation() async throws {
+    let service = InMemoryCalendarService(events: [FoundationModelsToolsFixtures.calendarEvent])
+    let tool = CalendarReadTool(service: service, now: { FoundationModelsToolsFixtures.date })
+
+    _ = try await tool.call(arguments: .init(action: "query", daysAhead: 1))
+
+    #expect(await service.readCallCount() == 1)
+    #expect(await service.mutationCallCount() == 0)
+  }
+
+  @Test("Calendar reads preserve long query ranges")
+  func calendarReadPreservesLongRanges() async throws {
+    let service = InMemoryCalendarService()
+    let tool = CalendarReadTool(service: service, now: { FoundationModelsToolsFixtures.date })
+
+    _ = try await tool.call(arguments: .init(action: "query", daysAhead: 730))
+
+    #expect(await service.readCallCount() == 1)
+  }
+
+  @Test("Calendar read access errors normalize to the stable tool error")
+  func calendarReadAccessErrorIsNormalized() async throws {
+    let service = InMemoryCalendarService(readAccessFailure: "EventKit unavailable")
+    let tool = CalendarReadTool(service: service)
+
+    do {
+      _ = try await tool.call(arguments: .init(action: "query"))
+      Issue.record("Expected read access to fail")
+    } catch let error as CalendarToolError {
+      guard case .accessDenied = error else {
+        Issue.record("Expected accessDenied, got \(error)")
+        return
+      }
+    }
+  }
+
+  @Test("Denied Calendar mutation never reaches the service")
+  func deniedCalendarMutationDoesNotExecute() async throws {
+    let service = InMemoryCalendarService()
+    let confirmer = ScriptedToolMutationConfirmer(.deny(reason: "User cancelled."))
+    let tool = CalendarMutationTool(service: service, confirmation: confirmer)
+
+    do {
+      _ = try await tool.execute(arguments: calendarCreateArguments)
+      Issue.record("Expected the mutation to be denied")
+    } catch let error as ToolMutationExecutionError {
+      #expect(error.receipt.status == .denied)
+      #expect(error.receipt.commitState == .notAttempted)
+      #expect(error.receipt.message == "User cancelled.")
+    }
+
+    #expect(await service.mutationCallCount() == 0)
+    #expect(await confirmer.requests().count == 1)
+  }
+
+  @Test("Approved Calendar mutation returns a committed receipt")
+  func approvedCalendarMutationCommits() async throws {
+    let service = InMemoryCalendarService()
+    let confirmer = ScriptedToolMutationConfirmer(.approve)
+    let tool = CalendarMutationTool(service: service, confirmation: confirmer)
+
+    let execution = try await tool.execute(arguments: calendarCreateArguments)
+
+    #expect(execution.receipt.status == .succeeded)
+    #expect(execution.receipt.commitState == .committed)
+    #expect(execution.receipt.resourceID == execution.value.id)
+    #expect(execution.value.title == "Safety review")
+    #expect(await service.mutationCallCount() == 1)
+    #expect(await service.events().count == 1)
+    let details = try #require(await confirmer.requests().first?.details)
+    #expect(details.contains(ToolMutationDetail(label: "Title", value: "Safety review")))
+    #expect(details.contains { $0.label == "Start" })
+    #expect(details.contains { $0.label == "End" })
+  }
+
+  @Test("Calendar service failure preserves its known commit state")
+  func calendarFailureReceiptIsTruthful() async throws {
+    let service = InMemoryCalendarService()
+    await service.setNextMutationFailure(
+      ToolMutationOperationError(
+        failureDescription: "Database rejected the event.",
+        commitState: .notCommitted
+      )
+    )
+    let tool = CalendarMutationTool(
+      service: service,
+      confirmation: ScriptedToolMutationConfirmer(.approve)
+    )
+
+    do {
+      _ = try await tool.execute(arguments: calendarCreateArguments)
+      Issue.record("Expected the service failure")
+    } catch let error as ToolMutationExecutionError {
+      #expect(error.receipt.status == .failed)
+      #expect(error.receipt.commitState == .notCommitted)
+      #expect(error.receipt.message == "Database rejected the event.")
+    }
+  }
+
+  @Test("Approved Calendar update targets the confirmed event")
+  func approvedCalendarUpdateCommits() async throws {
+    let original = FoundationModelsToolsFixtures.calendarEvent
+    let service = InMemoryCalendarService(events: [original])
+    let confirmer = ScriptedToolMutationConfirmer(.approve)
+    let tool = CalendarMutationTool(service: service, confirmation: confirmer)
+
+    let execution = try await tool.execute(
+      arguments: .init(
+        action: "update",
+        title: "Final design review",
+        eventId: original.id
+      )
+    )
+
+    #expect(execution.receipt.commitState == .committed)
+    #expect(execution.receipt.resourceID == original.id)
+    #expect(execution.value.title == "Final design review")
+    #expect(await confirmer.requests().first?.resourceID == original.id)
+  }
+
+  @Test("Confirmation failure is not reported as an attempted mutation")
+  func confirmationFailureDoesNotExecute() async throws {
+    let service = InMemoryCalendarService()
+    let confirmer = ScriptedToolMutationConfirmer(.fail(message: "Confirmation UI unavailable."))
+    let tool = CalendarMutationTool(service: service, confirmation: confirmer)
+
+    do {
+      _ = try await tool.execute(arguments: calendarCreateArguments)
+      Issue.record("Expected confirmation to fail")
+    } catch let error as ToolMutationExecutionError {
+      #expect(error.receipt.status == .failed)
+      #expect(error.receipt.commitState == .notAttempted)
+      #expect(error.receipt.message.contains("Confirmation UI unavailable"))
+    }
+
+    #expect(await service.mutationCallCount() == 0)
+  }
+
+  @available(*, deprecated)
+  @Test("Deprecated Calendar tool fails closed without app confirmation")
+  func combinedCalendarToolFailsClosed() async throws {
+    let tool = CalendarTool()
+
+    do {
+      _ = try await tool.call(
+        arguments: .init(
+          action: "create",
+          title: "Must not be written",
+          startDate: "2028-01-09 10:00:00"
+        )
+      )
+      Issue.record("Expected explicit confirmation to be required")
+    } catch let error as ToolMutationExecutionError {
+      #expect(error.receipt.status == .confirmationRequired)
+      #expect(error.receipt.commitState == .notAttempted)
+    }
+  }
+
+  @Test("Denied Reminder deletion is marked destructive and never executes")
+  func deniedReminderDeletionDoesNotExecute() async throws {
+    let service = InMemoryRemindersService(reminders: [FoundationModelsToolsFixtures.reminder])
+    let confirmer = ScriptedToolMutationConfirmer(.deny(reason: "Keep it."))
+    let tool = RemindersMutationTool(service: service, confirmation: confirmer)
+
+    do {
+      _ = try await tool.execute(
+        arguments: .init(action: "delete", reminderId: FoundationModelsToolsFixtures.reminder.id)
+      )
+      Issue.record("Expected deletion to be denied")
+    } catch let error as ToolMutationExecutionError {
+      #expect(error.receipt.status == .denied)
+      #expect(error.receipt.commitState == .notAttempted)
+      #expect(error.receipt.request.isDestructive)
+    }
+
+    #expect(await service.mutationCallCount() == 0)
+    #expect(await service.reminders().count == 1)
+  }
+
+  @Test("Approved Reminder completion records the exact completion time")
+  func approvedReminderCompletionCommits() async throws {
+    let service = InMemoryRemindersService(reminders: [FoundationModelsToolsFixtures.reminder])
+    let confirmer = ScriptedToolMutationConfirmer(.approve)
+    let tool = RemindersMutationTool(
+      service: service,
+      confirmation: confirmer,
+      now: { FoundationModelsToolsFixtures.date }
+    )
+
+    let execution = try await tool.execute(
+      arguments: .init(action: "complete", reminderId: FoundationModelsToolsFixtures.reminder.id)
+    )
+
+    #expect(execution.receipt.commitState == .committed)
+    #expect(execution.value.isCompleted)
+    #expect(execution.value.completionDate == fixedDate)
+    #expect(await service.mutationCallCount() == 1)
+  }
+
+  @Test("Reminder creation accepts none as no due date")
+  func reminderCreationAcceptsNoneDueDate() async throws {
+    let service = InMemoryRemindersService()
+    let tool = RemindersMutationTool(
+      service: service,
+      confirmation: ScriptedToolMutationConfirmer(.approve)
+    )
+
+    let execution = try await tool.execute(
+      arguments: .init(action: "create", title: "No deadline", dueDate: "none")
+    )
+
+    #expect(execution.value.dueDate == nil)
+    #expect(execution.receipt.commitState == .committed)
+    #expect(execution.receipt.resourceID == execution.value.id)
+  }
+
+  @Test("Malformed Reminder due dates fail before confirmation")
+  func malformedReminderDueDateDoesNotConfirmOrExecute() async throws {
+    let service = InMemoryRemindersService(reminders: [FoundationModelsToolsFixtures.reminder])
+    let confirmer = ScriptedToolMutationConfirmer(.approve)
+    let tool = RemindersMutationTool(service: service, confirmation: confirmer)
+
+    do {
+      _ = try await tool.execute(
+        arguments: .init(
+          action: "update",
+          title: "Other valid change",
+          dueDate: "not-a-date",
+          reminderId: FoundationModelsToolsFixtures.reminder.id
+        )
+      )
+      Issue.record("Expected invalid due date to fail")
+    } catch let error as RemindersToolError {
+      guard case .invalidDueDate = error else {
+        Issue.record("Expected invalidDueDate, got \(error)")
+        return
+      }
+    }
+
+    #expect(await confirmer.requests().isEmpty)
+    #expect(await service.mutationCallCount() == 0)
+  }
+
+  @Test("Approved Reminder create, update, and delete use one confirmation per mutation")
+  func reminderMutationLifecycleCommits() async throws {
+    let service = InMemoryRemindersService()
+    let confirmer = ScriptedToolMutationConfirmer([.approve, .approve, .approve])
+    let tool = RemindersMutationTool(
+      service: service,
+      confirmation: confirmer,
+      now: { FoundationModelsToolsFixtures.date }
+    )
+
+    let created = try await tool.execute(
+      arguments: .init(
+        action: "create",
+        title: "Verify release",
+        dueDate: "2028-01-09 10:00:00",
+        priority: "high",
+        listName: "Work"
+      )
+    )
+    let updated = try await tool.execute(
+      arguments: .init(
+        action: "update",
+        title: "Verify release tag",
+        dueDate: "none",
+        priority: "medium",
+        reminderId: created.value.id
+      )
+    )
+    let deleted = try await tool.execute(
+      arguments: .init(action: "delete", reminderId: created.value.id)
+    )
+
+    #expect(created.receipt.commitState == .committed)
+    #expect(updated.value.title == "Verify release tag")
+    #expect(updated.value.dueDate == nil)
+    #expect(updated.value.priority == .medium)
+    #expect(deleted.receipt.request.isDestructive)
+    #expect(await service.reminders().isEmpty)
+    #expect(await service.mutationCallCount() == 3)
+    #expect(await confirmer.requests().count == 3)
+  }
+
+  @Test("Reminder reads do not require mutation confirmation")
+  func reminderReadDoesNotRequireConfirmation() async throws {
+    let service = InMemoryRemindersService(reminders: [FoundationModelsToolsFixtures.reminder])
+    let tool = RemindersReadTool(service: service, now: { FoundationModelsToolsFixtures.date })
+
+    _ = try await tool.call(arguments: .init(filter: "all"))
+
+    #expect(await service.readCallCount() == 1)
+    #expect(await service.mutationCallCount() == 0)
+  }
+
+  @Test("Unknown Reminder filters preserve the incomplete fallback")
+  func unknownReminderFilterFallsBackToIncomplete() async throws {
+    let service = InMemoryRemindersService(reminders: [FoundationModelsToolsFixtures.reminder])
+    let tool = RemindersReadTool(service: service, now: { FoundationModelsToolsFixtures.date })
+
+    _ = try await tool.call(arguments: .init(filter: "typo"))
+
+    #expect(await service.readCallCount() == 1)
+  }
+
+  @Test("Reminders read access errors normalize to the stable tool error")
+  func remindersReadAccessErrorIsNormalized() async throws {
+    let service = InMemoryRemindersService(readAccessFailure: "EventKit unavailable")
+    let tool = RemindersReadTool(service: service)
+
+    do {
+      _ = try await tool.call(arguments: .init())
+      Issue.record("Expected read access to fail")
+    } catch let error as RemindersToolError {
+      guard case .accessDenied = error else {
+        Issue.record("Expected accessDenied, got \(error)")
+        return
+      }
+    }
+  }
+
+  @Test("In-memory today filter excludes completed reminders")
+  func reminderFixtureTodayFilterMatchesProduction() async throws {
+    let incomplete = FoundationModelsToolsFixtures.reminder
+    let completed = ReminderRecord(
+      id: "completed-today",
+      title: "Already done",
+      listName: "Work",
+      dueDate: fixedDate,
+      isCompleted: true,
+      completionDate: fixedDate
+    )
+    let service = InMemoryRemindersService(reminders: [incomplete, completed])
+
+    let matches = try await service.reminders(matching: .today, now: fixedDate)
+
+    #expect(matches.map(\.id) == [incomplete.id])
+  }
+
+  @Test("In-memory Calendar matches production date validation")
+  func calendarFixtureMatchesProductionDateValidation() async throws {
+    let original = FoundationModelsToolsFixtures.calendarEvent
+    let service = InMemoryCalendarService(events: [original])
+
+    do {
+      _ = try await service.updateCalendarEvent(
+        id: original.id,
+        changes: CalendarEventChanges(
+          endDate: original.startDate.addingTimeInterval(-60)
+        )
+      )
+      Issue.record("Expected invalid date order to fail")
+    } catch let error as ToolMutationOperationError {
+      #expect(error.commitState == .notAttempted)
+      #expect(error.failureDescription.contains("earlier"))
+    }
+
+    #expect(await service.events().first == original)
+  }
+
+  @Test("In-memory Calendar rejects invalid creates before persistence")
+  func calendarFixtureRejectsInvalidCreateDates() async throws {
+    let service = InMemoryCalendarService()
+    let draft = CalendarEventDraft(
+      title: "Invalid",
+      startDate: fixedDate,
+      endDate: fixedDate.addingTimeInterval(-60)
+    )
+
+    do {
+      _ = try await service.createCalendarEvent(draft)
+      Issue.record("Expected invalid date order to fail")
+    } catch let error as ToolMutationOperationError {
+      #expect(error.commitState == .notAttempted)
+    }
+
+    #expect(await service.events().isEmpty)
+  }
+
+  @available(*, deprecated)
+  @Test("Deprecated Reminders tool fails closed without app confirmation")
+  func combinedRemindersToolFailsClosed() async throws {
+    let tool = RemindersTool()
+
+    do {
+      _ = try await tool.call(arguments: .init(action: "delete", reminderId: "must-not-delete"))
+      Issue.record("Expected explicit confirmation to be required")
+    } catch let error as ToolMutationExecutionError {
+      #expect(error.receipt.status == .confirmationRequired)
+      #expect(error.receipt.commitState == .notAttempted)
+      #expect(error.receipt.request.isDestructive)
+    }
+  }
+
+  @Test("Reminders access denial produces a not-attempted failure receipt")
+  func remindersAccessDenialIsNotAttempted() async throws {
+    let service = InMemoryRemindersService(mutationAccess: false)
+    let tool = RemindersMutationTool(
+      service: service,
+      confirmation: ScriptedToolMutationConfirmer(.approve)
+    )
+
+    do {
+      _ = try await tool.execute(arguments: .init(action: "create", title: "No access"))
+      Issue.record("Expected access denial")
+    } catch let error as ToolMutationExecutionError {
+      #expect(error.receipt.status == .failed)
+      #expect(error.receipt.commitState == .notAttempted)
+      #expect(error.receipt.message.contains("denied"))
+    }
+
+    #expect(await service.mutationCallCount() == 0)
+  }
+
+  @Test("Mutation receipts round-trip through Codable")
+  func receiptCodableRoundTrip() throws {
+    let request = ToolMutationRequest(
+      id: UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!,
+      toolName: "mutateReminders",
+      action: "delete",
+      summary: "Delete reminder",
+      resourceID: "reminder-1",
+      isDestructive: true
+    )
+    let receipt = ToolMutationReceipt(
+      request: request,
+      status: .denied,
+      commitState: .notAttempted,
+      message: "User denied the request.",
+      resourceID: "reminder-1",
+      timestamp: fixedDate
+    )
+
+    let data = try JSONEncoder().encode(receipt)
+    let decoded = try JSONDecoder().decode(ToolMutationReceipt.self, from: data)
+
+    #expect(decoded == receipt)
+  }
+
+  private var calendarCreateArguments: CalendarMutationTool.Arguments {
+    .init(
+      action: "create",
+      title: "Safety review",
+      startDate: "2028-01-09 10:00:00",
+      endDate: "2028-01-09 11:00:00",
+      calendarName: "Work"
+    )
+  }
+}

--- a/Tests/FoundationModelsToolsTests/ToolQueryIdentifierTests.swift
+++ b/Tests/FoundationModelsToolsTests/ToolQueryIdentifierTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+
 @testable import FoundationModelsTools
 
 @Suite("Tool Query Identifier Tests")
@@ -17,7 +18,7 @@ struct ToolQueryIdentifierTests {
       notes: "Bring the spec"
     )
 
-    let output = CalendarTool.formatEventQueryResults([event])
+    let output = CalendarReadTool.formatEventQueryResults([event])
 
     #expect(output.contains("Event ID: event-123"))
     #expect(output.contains("Design Review"))
@@ -29,10 +30,10 @@ struct ToolQueryIdentifierTests {
       id: "reminder-456",
       title: "Ship audit fix",
       listName: "Engineering",
-      priority: 1
+      priority: .high
     )
 
-    let output = RemindersTool.formatReminderQueryResults([reminder])
+    let output = RemindersReadTool.formatReminderQueryResults([reminder])
 
     #expect(output.contains("Reminder ID: reminder-456"))
     #expect(output.contains("Ship audit fix"))


### PR DESCRIPTION
## Summary

- split Calendar and Reminders into read-only and mutation-only Foundation Models tools
- require an app-owned confirmation provider before mutation tools can be initialized or executed
- inject shared read and mutation services through public protocols backed by long-lived EventKit actors
- provide exact structured confirmation details for every field being changed
- throw typed failure receipts with explicit commit state and committed resource identifiers instead of returning failure-shaped successful tool output
- keep deprecated combined tools source-compatible while making their zero-argument mutation path fail closed
- publish FoundationModelsToolsTestSupport with deterministic fixtures, scripted confirmation, and in-memory services
- document the 3.0 migration and safe registration pattern

## Breaking change

CalendarTool() and RemindersTool() no longer execute writes. Existing read actions continue to work; mutations throw a confirmationRequired ToolMutationExecutionError until the host app supplies ToolMutationConfirming or migrates to the split mutation tools.

## Validation

- Xcode 27 Beta 4: swift test — 150 tests passed
- Xcode 26.6 RC 2: swift test — 149 tests passed
- Xcode 27 Beta 4: FoundationModelsTools iOS Simulator build passed
- Xcode 26.6 RC 2: FoundationModelsTools iOS Simulator build passed
- Swift API digester against 2.1.0: no source API breaks in existing products
- Cursor Bugbot: passed on latest head; all review threads resolved
- strict SwiftLint on every changed Swift file passed
- repository-wide strict SwiftLint still reports 23 pre-existing violations outside this diff