### PR TITLE
Fix build break: Transcript.Segment has no .custom case in current SDK

### DIFF
--- a/Sources/FoundationModelsKit/Extensions/Transcript+TokenCounting.swift
+++ b/Sources/FoundationModelsKit/Extensions/Transcript+TokenCounting.swift
@@ -119,9 +119,6 @@ extension Transcript.Segment {
     #if compiler(>=6.4)
     case .attachment(let attachmentSegment):
       return estimateTokens(from: attachmentSegment.label ?? "image attachment") + 12
-
-    case .custom(let customSegment):
-      return estimateTokens(from: customSegment.description)
     #endif
 
     @unknown default:


### PR DESCRIPTION
## Summary
- Removes handling for `Transcript.Segment.custom`, which no longer exists in the current SDK, fixing a build break in `Transcript+TokenCounting.swift`.

## Test plan
- [ ] Build the package and confirm it compiles against the current SDK