### PR TITLE
Fix Xcode 27 Beta 5 transcript token counting

### DIFF
--- a/Sources/FoundationModelsKit/Extensions/Transcript+TokenCounting.swift
+++ b/Sources/FoundationModelsKit/Extensions/Transcript+TokenCounting.swift
@@ -119,9 +119,6 @@ extension Transcript.Segment {
     #if compiler(>=6.4)
     case .attachment(let attachmentSegment):
       return estimateTokens(from: attachmentSegment.label ?? "image attachment") + 12
-
-    case .custom(let customSegment):
-      return estimateTokens(from: customSegment.description)
     #endif
 
     @unknown default:


### PR DESCRIPTION
## Summary

- remove the `Transcript.Segment.custom` match that was removed from the Xcode 27 Beta 5 SDK
- preserve image-attachment token estimation and the forward-compatible `@unknown default` fallback
- keep Xcode 26 behavior unchanged

## Validation

- Xcode 27 Beta 5: 150 tests passed
- Xcode 27 Beta 5: generic iOS Simulator build passed
- Xcode 26.6 RC 2: 149 tests passed
- Xcode 26.6 RC 2: generic iOS Simulator build passed
- changed file: strict SwiftLint passed with zero violations
- `git diff --check` passed

## Note

The repository-wide strict SwiftLint command currently reports 23 pre-existing violations outside this change.