### PR TITLE
Add typed tool result routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,35 @@ let result = try await policy.execute(
 }
 ```
 
+### Typed Tool Result Routing
+
+`FoundationModelToolResultRouter` collects the final decision for each tool call and maps successful outputs into an app-defined enum. This avoids forcing several tool result types through one generated response type.
+
+```swift
+enum HealthOutcome: Sendable {
+    case sleep(SleepSummary)
+    case exercise(ExerciseSummary)
+}
+
+let router = FoundationModelToolResultRouter<HealthOutcome>()
+try await router.recordSuccess(
+    tool: "sleep",
+    arguments: generatedArguments,
+    outcome: .sleep(summary)
+)
+
+switch await router.routingResult() {
+case .none:
+    break
+case .one(let outcome):
+    present(outcome)
+case .many(let outcomes):
+    presentAll(outcomes)
+}
+```
+
+The router keeps actor insertion order and doesn't pick one result when several tools succeed. It stores only an argument fingerprint by default; apps must opt in before raw generated arguments are retained. A fingerprint hides the original value from ordinary logs, but it isn't anonymization for low-entropy arguments.
+
 ### Evaluation Evidence
 
 Add `FoundationModelEvaluation` when an app or benchmark needs evidence that survives OS and device changes. `FoundationModelRuntimeFingerprint.capture()` records OS version and build, device identifier, locale, runtime, context size, and the public model variant when the SDK exposes it.

--- a/Sources/FoundationModelEvaluation/FoundationModelToolCallEvent+Invocation.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelToolCallEvent+Invocation.swift
@@ -1,0 +1,24 @@
+import Foundation
+import FoundationModelsKit
+
+public extension FoundationModelToolCallEvent {
+    /// Converts a routed invocation into the privacy-safe event stored by evaluation traces.
+    init<ToolOutcome>(
+        invocation: FoundationModelToolInvocation<ToolOutcome>
+    ) where ToolOutcome: Sendable {
+        let eventOutcome: FoundationModelToolCallEvent.Outcome
+        switch invocation.status {
+        case .succeeded:
+            eventOutcome = .succeeded
+        case .failed:
+            eventOutcome = .failed
+        case .loopDetected, .invalidArguments, .budgetExceeded, .confirmationRequired:
+            eventOutcome = .rejected
+        }
+        self.init(
+            sequence: invocation.sequence,
+            toolName: invocation.toolName,
+            outcome: eventOutcome
+        )
+    }
+}

--- a/Sources/FoundationModelsKit/Models/FoundationModelToolArgumentRecording.swift
+++ b/Sources/FoundationModelsKit/Models/FoundationModelToolArgumentRecording.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Controls whether a tool-result router retains generated arguments.
+public enum FoundationModelToolArgumentRecording: String, Codable, Equatable, Sendable {
+    /// Store only a deterministic fingerprint. This is the default.
+    case fingerprintOnly
+
+    /// Store the complete generated argument value alongside its fingerprint.
+    case includeArguments
+}

--- a/Sources/FoundationModelsKit/Models/FoundationModelToolArgumentRecording.swift
+++ b/Sources/FoundationModelsKit/Models/FoundationModelToolArgumentRecording.swift
@@ -5,6 +5,7 @@ public enum FoundationModelToolArgumentRecording: String, Codable, Equatable, Se
     /// Store only a deterministic fingerprint. This is the default.
     case fingerprintOnly
 
-    /// Store the complete generated argument value alongside its fingerprint.
+    /// Store the complete generated argument value alongside its fingerprint when it is valid JSON.
+    /// Unencodable rejected arguments are always omitted.
     case includeArguments
 }

--- a/Sources/FoundationModelsKit/Results/FoundationModelToolInvocation.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelToolInvocation.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// One finalized tool decision and its optional app-defined outcome.
+public struct FoundationModelToolInvocation<Outcome: Sendable>: Sendable {
+    public enum Status: String, Codable, Equatable, Sendable {
+        case succeeded
+        case loopDetected = "loop_detected"
+        case invalidArguments = "invalid_arguments"
+        case budgetExceeded = "budget_exceeded"
+        case confirmationRequired = "confirmation_required"
+        case failed
+    }
+
+    public let sequence: Int
+    public let identifier: UUID
+    public let toolName: String
+    public let argumentFingerprint: String
+    public let arguments: FoundationModelToolValue?
+    public let status: Status
+    public let outcome: Outcome?
+    public let failure: FoundationModelErrorProjection?
+    public let recordedAt: Date
+}
+
+extension FoundationModelToolInvocation: Equatable where Outcome: Equatable {}
+extension FoundationModelToolInvocation: Codable where Outcome: Codable {}

--- a/Sources/FoundationModelsKit/Results/FoundationModelToolRoutingResult.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelToolRoutingResult.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// The typed successful outcomes recorded during one model turn.
+public enum FoundationModelToolRoutingResult<Outcome: Sendable>: Sendable {
+    case none
+    case one(Outcome)
+    case many([Outcome])
+}
+
+extension FoundationModelToolRoutingResult: Equatable where Outcome: Equatable {}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelToolResultRouter.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelToolResultRouter.swift
@@ -1,0 +1,183 @@
+import Foundation
+
+/// Collects ordered tool decisions and routes successful results into an app-defined outcome type.
+public actor FoundationModelToolResultRouter<Outcome: Sendable> {
+    private struct InvocationRecord: Sendable {
+        let toolName: String
+        let arguments: FoundationModelToolValue
+        let identifier: UUID
+        let status: FoundationModelToolInvocation<Outcome>.Status
+        let outcome: Outcome?
+        let failure: FoundationModelErrorProjection?
+        let recordedAt: Date
+    }
+
+    private let argumentRecording: FoundationModelToolArgumentRecording
+    private var recordedInvocations: [FoundationModelToolInvocation<Outcome>] = []
+
+    public init(argumentRecording: FoundationModelToolArgumentRecording = .fingerprintOnly) {
+        self.argumentRecording = argumentRecording
+    }
+
+    /// Records a decision returned by ``FoundationModelToolExecutionPolicy``.
+    ///
+    /// The mapping closure runs only when the policy result is `succeeded`.
+    @discardableResult
+    public func record<Output: Sendable>(
+        tool toolName: String,
+        arguments: FoundationModelToolValue,
+        result: FoundationModelToolExecutionResult<Output>,
+        identifier: UUID = UUID(),
+        recordedAt: Date = Date(),
+        mapSuccess: @Sendable (Output) -> Outcome
+    ) throws -> FoundationModelToolInvocation<Outcome> {
+        switch result {
+        case .succeeded(let output, _, _):
+            return try append(InvocationRecord(
+                toolName: toolName,
+                arguments: arguments,
+                identifier: identifier,
+                status: .succeeded,
+                outcome: mapSuccess(output),
+                failure: nil,
+                recordedAt: recordedAt
+            ))
+        case .loopDetected:
+            return try appendPolicyDecision(
+                toolName: toolName,
+                arguments: arguments,
+                identifier: identifier,
+                status: .loopDetected,
+                recordedAt: recordedAt
+            )
+        case .invalidArguments:
+            return try appendPolicyDecision(
+                toolName: toolName,
+                arguments: arguments,
+                identifier: identifier,
+                status: .invalidArguments,
+                recordedAt: recordedAt
+            )
+        case .budgetExceeded:
+            return try appendPolicyDecision(
+                toolName: toolName,
+                arguments: arguments,
+                identifier: identifier,
+                status: .budgetExceeded,
+                recordedAt: recordedAt
+            )
+        case .confirmationRequired:
+            return try appendPolicyDecision(
+                toolName: toolName,
+                arguments: arguments,
+                identifier: identifier,
+                status: .confirmationRequired,
+                recordedAt: recordedAt
+            )
+        }
+    }
+
+    /// Records a successful tool call that did not run through the generic execution policy.
+    @discardableResult
+    public func recordSuccess(
+        tool toolName: String,
+        arguments: FoundationModelToolValue,
+        outcome: Outcome,
+        identifier: UUID = UUID(),
+        recordedAt: Date = Date()
+    ) throws -> FoundationModelToolInvocation<Outcome> {
+        try append(InvocationRecord(
+            toolName: toolName,
+            arguments: arguments,
+            identifier: identifier,
+            status: .succeeded,
+            outcome: outcome,
+            failure: nil,
+            recordedAt: recordedAt
+        ))
+    }
+
+    /// Records a thrown tool failure without retaining the error or its message.
+    @discardableResult
+    public func recordFailure(
+        tool toolName: String,
+        arguments: FoundationModelToolValue,
+        failure: FoundationModelErrorProjection? = nil,
+        identifier: UUID = UUID(),
+        recordedAt: Date = Date()
+    ) throws -> FoundationModelToolInvocation<Outcome> {
+        try append(InvocationRecord(
+            toolName: toolName,
+            arguments: arguments,
+            identifier: identifier,
+            status: .failed,
+            outcome: nil,
+            failure: failure,
+            recordedAt: recordedAt
+        ))
+    }
+
+    /// Returns a value copy of every finalized invocation in actor insertion order.
+    public func snapshot() -> [FoundationModelToolInvocation<Outcome>] {
+        recordedInvocations
+    }
+
+    /// Returns only successful typed outcomes without choosing between multiple tool calls.
+    public func routingResult() -> FoundationModelToolRoutingResult<Outcome> {
+        let outcomes = recordedInvocations.compactMap(\.outcome)
+        switch outcomes.count {
+        case 0:
+            return .none
+        case 1:
+            return .one(outcomes[0])
+        default:
+            return .many(outcomes)
+        }
+    }
+
+    private func appendPolicyDecision(
+        toolName: String,
+        arguments: FoundationModelToolValue,
+        identifier: UUID,
+        status: FoundationModelToolInvocation<Outcome>.Status,
+        recordedAt: Date
+    ) throws -> FoundationModelToolInvocation<Outcome> {
+        try append(InvocationRecord(
+            toolName: toolName,
+            arguments: arguments,
+            identifier: identifier,
+            status: status,
+            outcome: nil,
+            failure: nil,
+            recordedAt: recordedAt
+        ))
+    }
+
+    private func append(
+        _ record: InvocationRecord
+    ) throws -> FoundationModelToolInvocation<Outcome> {
+        let canonicalArguments = try record.arguments.canonicalJSONData()
+        let invocation = FoundationModelToolInvocation(
+            sequence: recordedInvocations.count,
+            identifier: record.identifier,
+            toolName: record.toolName,
+            argumentFingerprint: Self.fingerprint(canonicalArguments),
+            arguments: argumentRecording == .includeArguments ? record.arguments : nil,
+            status: record.status,
+            outcome: record.outcome,
+            failure: record.failure,
+            recordedAt: record.recordedAt
+        )
+        recordedInvocations.append(invocation)
+        return invocation
+    }
+
+    private static func fingerprint(_ data: Data) -> String {
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in data {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return String(hash, radix: 16)
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelToolResultRouter.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelToolResultRouter.swift
@@ -156,13 +156,13 @@ public actor FoundationModelToolResultRouter<Outcome: Sendable> {
     private func append(
         _ record: InvocationRecord
     ) throws -> FoundationModelToolInvocation<Outcome> {
-        let canonicalArguments = try record.arguments.canonicalJSONData()
+        let argumentEvidence = Self.argumentEvidence(for: record.arguments)
         let invocation = FoundationModelToolInvocation(
             sequence: recordedInvocations.count,
             identifier: record.identifier,
             toolName: record.toolName,
-            argumentFingerprint: Self.fingerprint(canonicalArguments),
-            arguments: argumentRecording == .includeArguments ? record.arguments : nil,
+            argumentFingerprint: Self.fingerprint(argumentEvidence.data),
+            arguments: argumentRecording == .includeArguments ? argumentEvidence.recordableValue : nil,
             status: record.status,
             outcome: record.outcome,
             failure: record.failure,
@@ -170,6 +170,39 @@ public actor FoundationModelToolResultRouter<Outcome: Sendable> {
         )
         recordedInvocations.append(invocation)
         return invocation
+    }
+
+    private static func argumentEvidence(
+        for arguments: FoundationModelToolValue
+    ) -> (data: Data, recordableValue: FoundationModelToolValue?) {
+        if let canonicalArguments = try? arguments.canonicalJSONData() {
+            return (canonicalArguments, arguments)
+        }
+
+        // A policy rejection can be caused by arguments that JSON cannot encode, such as NaN.
+        // Preserve a stable identity for diagnostics, but never retain the unencodable value.
+        let description = "non-json:\(nonJSONDescription(for: arguments))"
+        return (Data(description.utf8), nil)
+    }
+
+    private static func nonJSONDescription(for value: FoundationModelToolValue) -> String {
+        switch value {
+        case .object(let object):
+            let members = object.keys.sorted().map { key in
+                "\(key.utf8.count):\(key)=\(nonJSONDescription(for: object[key]!))"
+            }
+            return "object[\(members.joined(separator: ","))]"
+        case .array(let array):
+            return "array[\(array.map(nonJSONDescription).joined(separator: ","))]"
+        case .string(let string):
+            return "string:\(string.utf8.count):\(string)"
+        case .number(let number):
+            return "number:\(String(number.bitPattern, radix: 16))"
+        case .boolean(let boolean):
+            return "boolean:\(boolean)"
+        case .null:
+            return "null"
+        }
     }
 
     private static func fingerprint(_ data: Data) -> String {

--- a/Tests/FoundationModelEvaluationTests/FoundationModelToolCallEventInvocationTests.swift
+++ b/Tests/FoundationModelEvaluationTests/FoundationModelToolCallEventInvocationTests.swift
@@ -1,0 +1,24 @@
+import FoundationModelEvaluation
+import FoundationModelsKit
+import Testing
+
+@Suite("Routed tool evaluation events")
+struct ToolCallEventInvocationTests {
+    @Test("Router statuses map to stable evaluation outcomes")
+    func mapsRouterStatuses() async throws {
+        let router = FoundationModelToolResultRouter<String>()
+        let success = try await router.recordSuccess(
+            tool: "weather",
+            arguments: .object([:]),
+            outcome: "sunny"
+        )
+        let failure = try await router.recordFailure(
+            tool: "calendar",
+            arguments: .object([:]),
+            failure: FoundationModelErrorProjection(category: .networkFailure)
+        )
+
+        #expect(FoundationModelToolCallEvent(invocation: success).outcome == .succeeded)
+        #expect(FoundationModelToolCallEvent(invocation: failure).outcome == .failed)
+    }
+}

--- a/Tests/FoundationModelsKitTests/FoundationModelToolResultRouterTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelToolResultRouterTests.swift
@@ -93,6 +93,35 @@ struct FoundationModelToolResultRouterTests {
         #expect(await router.routingResult() == .none)
     }
 
+    @Test("Non-JSON policy rejections retain evidence without raw arguments")
+    func recordsNonJSONPolicyRejection() async throws {
+        let router = FoundationModelToolResultRouter<AppOutcome>(
+            argumentRecording: .includeArguments
+        )
+        let arguments = FoundationModelToolValue.object([
+            "value": .number(.nan)
+        ])
+        let policyResult = FoundationModelToolExecutionResult<Int>.invalidArguments([])
+
+        let invocation = try await router.record(
+            tool: "sleep",
+            arguments: arguments,
+            result: policyResult,
+            mapSuccess: { .exercise(minutes: $0) }
+        )
+        let repeated = try await router.record(
+            tool: "sleep",
+            arguments: arguments,
+            result: policyResult,
+            mapSuccess: { .exercise(minutes: $0) }
+        )
+
+        #expect(invocation.status == .invalidArguments)
+        #expect(invocation.arguments == nil)
+        #expect(invocation.argumentFingerprint == repeated.argumentFingerprint)
+        #expect(await router.snapshot().count == 2)
+    }
+
     @Test("Projected failures remain typed and Codable")
     func recordsAndRoundTripsFailure() async throws {
         let router = FoundationModelToolResultRouter<AppOutcome>()

--- a/Tests/FoundationModelsKitTests/FoundationModelToolResultRouterTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelToolResultRouterTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import FoundationModelsKit
+
+@Suite("Tool result router")
+struct FoundationModelToolResultRouterTests {
+    private enum AppOutcome: Codable, Equatable, Sendable {
+        case sleep(hours: Double)
+        case exercise(minutes: Int)
+    }
+
+    @Test("No successful tools produces no routed outcome")
+    func noSuccessfulTools() async {
+        let router = FoundationModelToolResultRouter<AppOutcome>()
+
+        #expect(await router.routingResult() == .none)
+        #expect(await router.snapshot().isEmpty)
+    }
+
+    @Test("Different tool result types route through one app enum")
+    func routesTypedOutcomesInOrder() async throws {
+        let router = FoundationModelToolResultRouter<AppOutcome>()
+        let first = try await router.recordSuccess(
+            tool: "sleep",
+            arguments: .object(["month": .string("November")]),
+            outcome: .sleep(hours: 7.5),
+            identifier: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+            recordedAt: Date(timeIntervalSince1970: 1_000)
+        )
+        let second = try await router.recordSuccess(
+            tool: "exercise",
+            arguments: .object(["days": .number(7)]),
+            outcome: .exercise(minutes: 90),
+            identifier: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+            recordedAt: Date(timeIntervalSince1970: 1_001)
+        )
+
+        #expect(first.sequence == 0)
+        #expect(second.sequence == 1)
+        #expect(
+            await router.routingResult() == .many([
+                .sleep(hours: 7.5),
+                .exercise(minutes: 90)
+            ])
+        )
+    }
+
+    @Test("Raw arguments are omitted by default and can be explicitly retained")
+    func controlsArgumentRecording() async throws {
+        let arguments = FoundationModelToolValue.object([
+            "a": .number(1),
+            "b": .number(2)
+        ])
+        let reordered = FoundationModelToolValue.object([
+            "b": .number(2),
+            "a": .number(1)
+        ])
+        let defaultRouter = FoundationModelToolResultRouter<AppOutcome>()
+        let retainingRouter = FoundationModelToolResultRouter<AppOutcome>(
+            argumentRecording: .includeArguments
+        )
+
+        let omitted = try await defaultRouter.recordSuccess(
+            tool: "sleep",
+            arguments: arguments,
+            outcome: .sleep(hours: 8)
+        )
+        let retained = try await retainingRouter.recordSuccess(
+            tool: "sleep",
+            arguments: reordered,
+            outcome: .sleep(hours: 8)
+        )
+
+        #expect(omitted.arguments == nil)
+        #expect(retained.arguments == reordered)
+        #expect(omitted.argumentFingerprint == retained.argumentFingerprint)
+    }
+
+    @Test("Policy decisions record rejections without routing an outcome")
+    func recordsPolicyDecision() async throws {
+        let router = FoundationModelToolResultRouter<AppOutcome>()
+        let policyResult = FoundationModelToolExecutionResult<Int>.invalidArguments([])
+
+        let invocation = try await router.record(
+            tool: "sleep",
+            arguments: .object([:]),
+            result: policyResult,
+            mapSuccess: { .exercise(minutes: $0) }
+        )
+
+        #expect(invocation.status == .invalidArguments)
+        #expect(invocation.outcome == nil)
+        #expect(await router.routingResult() == .none)
+    }
+
+    @Test("Projected failures remain typed and Codable")
+    func recordsAndRoundTripsFailure() async throws {
+        let router = FoundationModelToolResultRouter<AppOutcome>()
+        let invocation = try await router.recordFailure(
+            tool: "sleep",
+            arguments: .object([:]),
+            failure: FoundationModelErrorProjection(category: .networkFailure),
+            identifier: UUID(uuidString: "00000000-0000-0000-0000-000000000003")!,
+            recordedAt: Date(timeIntervalSince1970: 1_002)
+        )
+
+        let data = try JSONEncoder().encode(invocation)
+        let decoded = try JSONDecoder().decode(
+            FoundationModelToolInvocation<AppOutcome>.self,
+            from: data
+        )
+
+        #expect(decoded == invocation)
+        #expect(decoded.failure?.category == .networkFailure)
+    }
+}


### PR DESCRIPTION
## Summary\n\nAdd an actor-backed FoundationModelToolResultRouter that preserves final tool decisions in insertion order and maps successful outputs into an app-defined Sendable outcome type.\n\nThe router represents zero, one, or several successful outcomes without choosing one on behalf of the app. It records execution-policy rejections and projected failures, omits raw generated arguments by default, and can retain them only through an explicit option.\n\nFoundationModelEvaluation can convert routed invocations into its existing tool-call events.\n\n## Validation\n\n- Xcode 26.6 RC 2: 190 tests passed in 32 suites.\n- Xcode 27 beta 5: tools, core, and evaluation test runs passed.\n- Strict SwiftLint passed for every changed Swift file.\n- git diff --check passed.\n\nApple forum case: https://developer.apple.com/forums/thread/811381