### PR TITLE
Add deterministic evaluation record and replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,19 @@ Add `FoundationModelEvaluation` when an app or benchmark needs evidence that sur
 
 `FoundationModelEvaluationRunner` records ordered tool events, repair count, latency, token usage, schema validity, refusal or error category, and final success without collecting prompt or response text. `FoundationModelFeedbackBundleBuilder` can pair that trace with `LanguageModelSession.logFeedbackAttachment`; Apple's attachment may contain session content, so consent and redaction stay with the app.
 
+For deterministic tests, wrap any `FoundationModelTextGenerating` implementation in `FoundationModelRecordingTextGenerator`, export its `FoundationModelTextGenerationCassette`, then load that cassette with `FoundationModelReplayTextGenerator`. Replays match every semantic request field except the correlation ID and consume repeated recordings in their original request order.
+
+```swift
+let recorder = FoundationModelRecordingTextGenerator(base: liveGenerator)
+_ = try await recorder.generateText(for: request)
+let cassette = await recorder.cassette()
+
+let replay = try FoundationModelReplayTextGenerator(cassette: cassette)
+let deterministicResult = try await replay.generateText(for: request)
+```
+
+Cassettes contain complete prompts, instructions, adapter URLs, and responses. Creating or exporting one is an explicit app decision; the package doesn't redact or persist it automatically. `FoundationModelEvaluationSnapshot` removes run IDs, dates, and latency so checked-in golden comparisons report drift only in stable evaluation fields.
+
 ### Tools
 
 `FoundationModelsTools` provides tools for real app capabilities. Calendar and Reminders reads are separate from mutations. Mutation tools cannot be initialized without an app-owned confirmation provider, and model-authored arguments never contain an approval flag.

--- a/Sources/FoundationModelEvaluation/FoundationModelEvaluationComparison.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelEvaluationComparison.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Exact field differences between expected and observed evaluation snapshots.
+public struct FoundationModelEvaluationComparison: Codable, Equatable, Sendable {
+    public enum Field: String, Codable, CaseIterable, Equatable, Sendable {
+        case fingerprint
+        case toolCallSequence = "tool_call_sequence"
+        case repairCount = "repair_count"
+        case tokenUsage = "token_usage"
+        case schemaValid = "schema_valid"
+        case outcome
+        case refusalOrErrorCategory = "refusal_or_error_category"
+        case finalSuccess = "final_success"
+    }
+
+    public let mismatchedFields: [Field]
+
+    public var passed: Bool {
+        mismatchedFields.isEmpty
+    }
+
+    public init(
+        expected: FoundationModelEvaluationSnapshot,
+        actual: FoundationModelEvaluationSnapshot
+    ) {
+        var fields: [Field] = []
+        if expected.fingerprint != actual.fingerprint { fields.append(.fingerprint) }
+        if expected.toolCallSequence != actual.toolCallSequence { fields.append(.toolCallSequence) }
+        if expected.repairCount != actual.repairCount { fields.append(.repairCount) }
+        if expected.tokenUsage != actual.tokenUsage { fields.append(.tokenUsage) }
+        if expected.schemaValid != actual.schemaValid { fields.append(.schemaValid) }
+        if expected.outcome != actual.outcome { fields.append(.outcome) }
+        if expected.refusalOrErrorCategory != actual.refusalOrErrorCategory {
+            fields.append(.refusalOrErrorCategory)
+        }
+        if expected.finalSuccess != actual.finalSuccess { fields.append(.finalSuccess) }
+        self.mismatchedFields = fields
+    }
+}

--- a/Sources/FoundationModelEvaluation/FoundationModelEvaluationSnapshot.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelEvaluationSnapshot.swift
@@ -1,0 +1,28 @@
+import Foundation
+import FoundationModelsKit
+
+/// Stable evaluation evidence suitable for a checked-in golden file.
+public struct FoundationModelEvaluationSnapshot: Codable, Equatable, Sendable {
+    public let fingerprint: FoundationModelRuntimeFingerprint?
+    public let toolCallSequence: [FoundationModelToolCallEvent]
+    public let repairCount: Int
+    public let tokenUsage: ModelTokenUsage?
+    public let schemaValid: Bool?
+    public let outcome: FoundationModelEvaluationOutcome
+    public let refusalOrErrorCategory: FoundationModelErrorProjection.Category?
+    public let finalSuccess: Bool
+
+    public init(
+        trace: FoundationModelExecutionTrace,
+        includeFingerprint: Bool = true
+    ) {
+        self.fingerprint = includeFingerprint ? trace.fingerprint : nil
+        self.toolCallSequence = trace.toolCallSequence
+        self.repairCount = trace.repairCount
+        self.tokenUsage = trace.tokenUsage
+        self.schemaValid = trace.schemaValid
+        self.outcome = trace.outcome
+        self.refusalOrErrorCategory = trace.refusalOrErrorCategory
+        self.finalSuccess = trace.finalSuccess
+    }
+}

--- a/Sources/FoundationModelEvaluation/FoundationModelRecordedGenerationOutcome.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelRecordedGenerationOutcome.swift
@@ -1,0 +1,9 @@
+import Foundation
+import FoundationModelsKit
+
+/// The stable result retained for one recorded text-generation request.
+public enum FoundationModelRecordedGenerationOutcome: Codable, Equatable, Sendable {
+    case success(FoundationModelTextGenerationResult)
+    case failure(FoundationModelErrorProjection)
+    case cancelled
+}

--- a/Sources/FoundationModelEvaluation/FoundationModelRecordingTextGenerator.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelRecordingTextGenerator.swift
@@ -1,0 +1,68 @@
+import Foundation
+import FoundationModelsKit
+
+/// Records explicit text-generation requests and stable outcomes while forwarding to a real provider.
+public actor FoundationModelRecordingTextGenerator: FoundationModelTextGenerating {
+    public typealias ErrorProjector = @Sendable (any Error) -> FoundationModelErrorProjection?
+
+    private let base: any FoundationModelTextGenerating
+    private let errorProjector: ErrorProjector
+    private var nextSequence = 0
+    private var recordedResults: [FoundationModelTextGenerationRecord] = []
+
+    public init(
+        base: any FoundationModelTextGenerating,
+        errorProjector: @escaping ErrorProjector = FoundationModelErrorProjection.project
+    ) {
+        self.base = base
+        self.errorProjector = errorProjector
+    }
+
+    public func generateText(
+        for request: FoundationModelTextGenerationRequest
+    ) async throws -> FoundationModelTextGenerationResult {
+        let sequence = nextSequence
+        nextSequence += 1
+
+        do {
+            let result = try await base.generateText(for: request)
+            recordedResults.append(FoundationModelTextGenerationRecord(
+                sequence: sequence,
+                request: request,
+                outcome: .success(result)
+            ))
+            return result
+        } catch is CancellationError {
+            recordedResults.append(FoundationModelTextGenerationRecord(
+                sequence: sequence,
+                request: request,
+                outcome: .cancelled
+            ))
+            throw CancellationError()
+        } catch {
+            recordedResults.append(FoundationModelTextGenerationRecord(
+                sequence: sequence,
+                request: request,
+                outcome: .failure(
+                    errorProjector(error) ?? FoundationModelErrorProjection(category: .unknown)
+                )
+            ))
+            throw error
+        }
+    }
+
+    /// Returns recordings in request-start order, even if concurrent requests finish out of order.
+    public func records() -> [FoundationModelTextGenerationRecord] {
+        recordedResults.sorted { $0.sequence < $1.sequence }
+    }
+
+    /// Packages current recordings with public runtime metadata for export or replay.
+    public func cassette(
+        fingerprint: FoundationModelRuntimeFingerprint = .current
+    ) -> FoundationModelTextGenerationCassette {
+        FoundationModelTextGenerationCassette(
+            fingerprint: fingerprint,
+            records: recordedResults
+        )
+    }
+}

--- a/Sources/FoundationModelEvaluation/FoundationModelReplayError.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelReplayError.swift
@@ -1,0 +1,27 @@
+import Foundation
+import FoundationModelsKit
+
+/// A deterministic cassette validation or replay failure.
+public enum FoundationModelReplayError: Error, Equatable, Sendable {
+    case unsupportedFormatVersion(Int)
+    case invalidSequence(Int)
+    case duplicateSequence(Int)
+    case noMatchingRecording(requestFingerprint: String)
+    case recordingExhausted(requestFingerprint: String)
+    case recordedFailure(FoundationModelErrorProjection)
+}
+
+extension FoundationModelReplayError: FoundationModelProjectedError {
+    public var foundationModelErrorProjection: FoundationModelErrorProjection {
+        switch self {
+        case .recordedFailure(let projection):
+            projection
+        case .unsupportedFormatVersion,
+             .invalidSequence,
+             .duplicateSequence,
+             .noMatchingRecording,
+             .recordingExhausted:
+            FoundationModelErrorProjection(category: .unknown)
+        }
+    }
+}

--- a/Sources/FoundationModelEvaluation/FoundationModelReplayTextGenerator.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelReplayTextGenerator.swift
@@ -1,0 +1,99 @@
+import Foundation
+import FoundationModelsKit
+
+/// A deterministic ``FoundationModelTextGenerating`` fake backed by an exported cassette.
+public actor FoundationModelReplayTextGenerator: FoundationModelTextGenerating {
+    private struct RequestKey: Codable, Hashable, Sendable {
+        let prompt: String
+        let systemPrompt: String?
+        let modelUseCase: FoundationModelUseCase
+        let guardrails: FoundationModelGuardrails?
+        let adapterURL: URL?
+        let generationOptions: FoundationModelGenerationOptions?
+        let source: FoundationModelInvocationSource
+        let localeIdentifier: String?
+
+        init(request: FoundationModelTextGenerationRequest) {
+            self.prompt = request.prompt
+            self.systemPrompt = request.systemPrompt
+            self.modelUseCase = request.modelUseCase
+            self.guardrails = request.guardrails
+            self.adapterURL = request.adapterURL
+            self.generationOptions = request.generationOptions
+            self.source = request.context.source
+            self.localeIdentifier = request.context.localeIdentifier
+        }
+    }
+
+    public nonisolated let fingerprint: FoundationModelRuntimeFingerprint
+
+    private let recordsByKey: [RequestKey: [FoundationModelTextGenerationRecord]]
+    private var consumedCounts: [RequestKey: Int] = [:]
+
+    public init(cassette: FoundationModelTextGenerationCassette) throws {
+        guard cassette.formatVersion == FoundationModelTextGenerationCassette.currentFormatVersion else {
+            throw FoundationModelReplayError.unsupportedFormatVersion(cassette.formatVersion)
+        }
+
+        var seenSequences: Set<Int> = []
+        var recordsByKey: [RequestKey: [FoundationModelTextGenerationRecord]] = [:]
+        for record in cassette.records.sorted(by: { $0.sequence < $1.sequence }) {
+            guard record.sequence >= 0 else {
+                throw FoundationModelReplayError.invalidSequence(record.sequence)
+            }
+            guard seenSequences.insert(record.sequence).inserted else {
+                throw FoundationModelReplayError.duplicateSequence(record.sequence)
+            }
+            recordsByKey[RequestKey(request: record.request), default: []].append(record)
+        }
+
+        self.fingerprint = cassette.fingerprint
+        self.recordsByKey = recordsByKey
+    }
+
+    public func generateText(
+        for request: FoundationModelTextGenerationRequest
+    ) async throws -> FoundationModelTextGenerationResult {
+        let key = RequestKey(request: request)
+        let fingerprint = try Self.fingerprint(key)
+        guard let records = recordsByKey[key] else {
+            throw FoundationModelReplayError.noMatchingRecording(
+                requestFingerprint: fingerprint
+            )
+        }
+
+        let index = consumedCounts[key, default: 0]
+        guard records.indices.contains(index) else {
+            throw FoundationModelReplayError.recordingExhausted(
+                requestFingerprint: fingerprint
+            )
+        }
+        consumedCounts[key] = index + 1
+
+        switch records[index].outcome {
+        case .success(let result):
+            return result
+        case .failure(let projection):
+            throw FoundationModelReplayError.recordedFailure(projection)
+        case .cancelled:
+            throw CancellationError()
+        }
+    }
+
+    /// Returns the number of cassette entries consumed across all semantic request keys.
+    public func consumedRecordCount() -> Int {
+        consumedCounts.values.reduce(0, +)
+    }
+
+    private static func fingerprint(_ key: RequestKey) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(key)
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for byte in data {
+            hash ^= UInt64(byte)
+            hash &*= 1_099_511_628_211
+        }
+        return String(hash, radix: 16)
+    }
+}

--- a/Sources/FoundationModelEvaluation/FoundationModelTextGenerationCassette.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelTextGenerationCassette.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Codable text-generation recordings paired with the runtime where they were captured.
+public struct FoundationModelTextGenerationCassette: Codable, Equatable, Sendable {
+    public static let currentFormatVersion = 1
+
+    public let formatVersion: Int
+    public let fingerprint: FoundationModelRuntimeFingerprint
+    public let records: [FoundationModelTextGenerationRecord]
+
+    public init(
+        formatVersion: Int = currentFormatVersion,
+        fingerprint: FoundationModelRuntimeFingerprint,
+        records: [FoundationModelTextGenerationRecord]
+    ) {
+        self.formatVersion = formatVersion
+        self.fingerprint = fingerprint
+        self.records = records.sorted { $0.sequence < $1.sequence }
+    }
+}

--- a/Sources/FoundationModelEvaluation/FoundationModelTextGenerationRecord.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelTextGenerationRecord.swift
@@ -1,0 +1,19 @@
+import Foundation
+import FoundationModelsKit
+
+/// One request and outcome captured by ``FoundationModelRecordingTextGenerator``.
+public struct FoundationModelTextGenerationRecord: Codable, Equatable, Sendable {
+    public let sequence: Int
+    public let request: FoundationModelTextGenerationRequest
+    public let outcome: FoundationModelRecordedGenerationOutcome
+
+    public init(
+        sequence: Int,
+        request: FoundationModelTextGenerationRequest,
+        outcome: FoundationModelRecordedGenerationOutcome
+    ) {
+        self.sequence = max(0, sequence)
+        self.request = request
+        self.outcome = outcome
+    }
+}

--- a/Sources/FoundationModelsKit/Errors/FoundationModelErrorProjection.swift
+++ b/Sources/FoundationModelsKit/Errors/FoundationModelErrorProjection.swift
@@ -50,6 +50,10 @@ public struct FoundationModelErrorProjection: Sendable, Hashable, Codable {
     }
 
     public static func project(_ error: any Error) -> Self? {
+        if let projectedError = error as? any FoundationModelProjectedError {
+            return projectedError.foundationModelErrorProjection
+        }
+
         if let generationError = error as? LanguageModelSession.GenerationError {
             return project(generationError)
         }

--- a/Sources/FoundationModelsKit/Errors/FoundationModelProjectedError.swift
+++ b/Sources/FoundationModelsKit/Errors/FoundationModelProjectedError.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// An app or package error that exposes a stable Foundation Models error projection.
+public protocol FoundationModelProjectedError: Error, Sendable {
+    var foundationModelErrorProjection: FoundationModelErrorProjection { get }
+}

--- a/Sources/FoundationModelsKit/Requests/FoundationModelTextGenerationRequest.swift
+++ b/Sources/FoundationModelsKit/Requests/FoundationModelTextGenerationRequest.swift
@@ -1,5 +1,9 @@
 import Foundation
-public struct FoundationModelTextGenerationRequest: FoundationModelCapabilityRequest, Sendable {
+public struct FoundationModelTextGenerationRequest:
+    FoundationModelCapabilityRequest,
+    Codable,
+    Hashable,
+    Sendable {
     public let prompt: String
     public let systemPrompt: String?
     public let modelUseCase: FoundationModelUseCase

--- a/Sources/FoundationModelsKit/Results/FoundationModelTextGenerationResult.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelTextGenerationResult.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-public struct FoundationModelTextGenerationResult: FoundationModelCapabilityResult, Sendable, Hashable {
+public struct FoundationModelTextGenerationResult:
+    FoundationModelCapabilityResult,
+    Codable,
+    Hashable,
+    Sendable {
     public let content: String
     public let metadata: FoundationModelExecutionMetadata
 

--- a/Tests/FoundationModelEvaluationTests/FoundationModelRecordReplayTests.swift
+++ b/Tests/FoundationModelEvaluationTests/FoundationModelRecordReplayTests.swift
@@ -1,0 +1,240 @@
+import Foundation
+import FoundationModelEvaluation
+import FoundationModelsKit
+import Testing
+
+@Suite("Foundation Model record and replay")
+struct FoundationModelRecordReplayTests {
+    @Test("Recorder captures successful output and runtime metadata")
+    func recordsSuccess() async throws {
+        let result = FoundationModelTextGenerationResult(
+            content: "Recorded answer",
+            metadata: FoundationModelExecutionMetadata(tokenCount: 4)
+        )
+        let recorder = FoundationModelRecordingTextGenerator(
+            base: ScriptedTextGenerator(outcomes: [.success(result)])
+        )
+
+        let observed = try await recorder.generateText(for: request(correlationID: UUID()))
+        let cassette = await recorder.cassette(fingerprint: testFingerprint)
+
+        #expect(observed == result)
+        #expect(cassette.fingerprint == testFingerprint)
+        #expect(cassette.records.count == 1)
+        #expect(cassette.records[0].outcome == .success(result))
+    }
+
+    @Test("Replay ignores correlation IDs and consumes repeated requests in order")
+    func replaysRepeatedRequests() async throws {
+        let first = FoundationModelTextGenerationResult(content: "first")
+        let second = FoundationModelTextGenerationResult(content: "second")
+        let recordedRequest = request(
+            correlationID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+        )
+        let cassette = FoundationModelTextGenerationCassette(
+            fingerprint: testFingerprint,
+            records: [
+                FoundationModelTextGenerationRecord(
+                    sequence: 0,
+                    request: recordedRequest,
+                    outcome: .success(first)
+                ),
+                FoundationModelTextGenerationRecord(
+                    sequence: 1,
+                    request: recordedRequest,
+                    outcome: .success(second)
+                )
+            ]
+        )
+        let replay = try FoundationModelReplayTextGenerator(cassette: cassette)
+        let replayRequest = request(
+            correlationID: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+        )
+
+        #expect(try await replay.generateText(for: replayRequest) == first)
+        #expect(try await replay.generateText(for: replayRequest) == second)
+        await #expect(throws: FoundationModelReplayError.self) {
+            _ = try await replay.generateText(for: replayRequest)
+        }
+        #expect(await replay.consumedRecordCount() == 2)
+    }
+
+    @Test("Recorded failures keep their projected category during replay")
+    func replaysProjectedFailure() async throws {
+        let cassette = FoundationModelTextGenerationCassette(
+            fingerprint: testFingerprint,
+            records: [
+                FoundationModelTextGenerationRecord(
+                    sequence: 0,
+                    request: request(correlationID: UUID()),
+                    outcome: .failure(
+                        FoundationModelErrorProjection(category: .rateLimited)
+                    )
+                )
+            ]
+        )
+        let replay = try FoundationModelReplayTextGenerator(cassette: cassette)
+
+        do {
+            _ = try await replay.generateText(for: request(correlationID: UUID()))
+            Issue.record("Expected the recorded failure")
+        } catch {
+            #expect(FoundationModelErrorProjection.project(error)?.category == .rateLimited)
+        }
+    }
+
+    @Test("Replay preserves recorded cancellation")
+    func replaysCancellation() async throws {
+        let cassette = FoundationModelTextGenerationCassette(
+            fingerprint: testFingerprint,
+            records: [
+                FoundationModelTextGenerationRecord(
+                    sequence: 0,
+                    request: request(correlationID: UUID()),
+                    outcome: .cancelled
+                )
+            ]
+        )
+        let replay = try FoundationModelReplayTextGenerator(cassette: cassette)
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await replay.generateText(for: request(correlationID: UUID()))
+        }
+    }
+
+    @Test("Cassettes round-trip requests and responses")
+    func cassetteRoundTrips() throws {
+        let cassette = FoundationModelTextGenerationCassette(
+            fingerprint: testFingerprint,
+            records: [
+                FoundationModelTextGenerationRecord(
+                    sequence: 0,
+                    request: request(correlationID: UUID()),
+                    outcome: .success(FoundationModelTextGenerationResult(content: "answer"))
+                )
+            ]
+        )
+
+        let data = try JSONEncoder().encode(cassette)
+        let decoded = try JSONDecoder().decode(
+            FoundationModelTextGenerationCassette.self,
+            from: data
+        )
+
+        #expect(decoded == cassette)
+    }
+
+    @Test("Golden comparisons exclude timing and report stable field drift")
+    func comparesStableEvaluationFields() {
+        let firstTrace = trace(
+            id: UUID(),
+            startedAt: Date(timeIntervalSince1970: 100),
+            finishedAt: Date(timeIntervalSince1970: 101),
+            finalSuccess: true
+        )
+        let timingOnlyTrace = trace(
+            id: UUID(),
+            startedAt: Date(timeIntervalSince1970: 200),
+            finishedAt: Date(timeIntervalSince1970: 250),
+            finalSuccess: true
+        )
+        let failedTrace = trace(
+            id: UUID(),
+            startedAt: Date(timeIntervalSince1970: 300),
+            finishedAt: Date(timeIntervalSince1970: 301),
+            finalSuccess: false
+        )
+        let expected = FoundationModelEvaluationSnapshot(trace: firstTrace)
+
+        #expect(
+            FoundationModelEvaluationComparison(
+                expected: expected,
+                actual: FoundationModelEvaluationSnapshot(trace: timingOnlyTrace)
+            ).passed
+        )
+        #expect(
+            FoundationModelEvaluationComparison(
+                expected: expected,
+                actual: FoundationModelEvaluationSnapshot(trace: failedTrace)
+            ).mismatchedFields == [.finalSuccess]
+        )
+    }
+
+    private func request(correlationID: UUID) -> FoundationModelTextGenerationRequest {
+        FoundationModelTextGenerationRequest(
+            prompt: "Prompt",
+            systemPrompt: "Instructions",
+            generationOptions: FoundationModelGenerationOptions(temperature: 0.2),
+            context: FoundationModelInvocationContext(
+                source: .automation,
+                localeIdentifier: "en_US",
+                correlationID: correlationID
+            )
+        )
+    }
+
+    private func trace(
+        id: UUID,
+        startedAt: Date,
+        finishedAt: Date,
+        finalSuccess: Bool
+    ) -> FoundationModelExecutionTrace {
+        FoundationModelExecutionTrace(
+            id: id,
+            startedAt: startedAt,
+            finishedAt: finishedAt,
+            fingerprint: testFingerprint,
+            latency: FoundationModelLatency(
+                total: finishedAt.timeIntervalSince(startedAt)
+            ),
+            outcome: .completed,
+            finalSuccess: finalSuccess
+        )
+    }
+
+    private var testFingerprint: FoundationModelRuntimeFingerprint {
+        FoundationModelRuntimeFingerprint(
+            operatingSystemName: "macOS",
+            operatingSystemVersion: "26.6",
+            operatingSystemBuild: "25G1",
+            deviceModelIdentifier: "Mac16,1",
+            modelVariant: "Core 3",
+            contextSize: 4_096,
+            runtime: .onDevice,
+            localeIdentifier: "en_US"
+        )
+    }
+}
+
+private actor ScriptedTextGenerator: FoundationModelTextGenerating {
+    enum Outcome: Sendable {
+        case success(FoundationModelTextGenerationResult)
+        case failure(FoundationModelErrorProjection)
+        case cancelled
+    }
+
+    private var outcomes: [Outcome]
+
+    init(outcomes: [Outcome]) {
+        self.outcomes = outcomes
+    }
+
+    func generateText(
+        for request: FoundationModelTextGenerationRequest
+    ) async throws -> FoundationModelTextGenerationResult {
+        _ = request
+        guard !outcomes.isEmpty else {
+            throw FoundationModelReplayError.recordingExhausted(
+                requestFingerprint: "script"
+            )
+        }
+        switch outcomes.removeFirst() {
+        case .success(let result):
+            return result
+        case .failure(let projection):
+            throw FoundationModelReplayError.recordedFailure(projection)
+        case .cancelled:
+            throw CancellationError()
+        }
+    }
+}


### PR DESCRIPTION
## Summary\n\nAdd explicit text-generation recording and deterministic replay to FoundationModelEvaluation using the existing FoundationModelTextGenerating protocol.\n\nRecordings preserve semantic request fields, results, projected failures, cancellation, request order, and the public runtime fingerprint. Replay ignores correlation IDs, consumes repeated requests in recorded order, validates cassette versions and sequences, and exposes recorded failures through FoundationModelErrorProjection.\n\nAdd stable evaluation snapshots and field-level comparisons for checked-in golden files. Run IDs, dates, and latency do not affect those comparisons.\n\n## Privacy\n\nCassettes contain complete prompts, instructions, adapter URLs, and responses. The package records only when an app constructs the recorder, and it never writes a cassette to disk automatically.\n\n## Validation\n\n- Xcode 26.6 RC 2: 190 tests passed in 31 suites.\n- Xcode 27 beta 5: tools, core, and evaluation test runs passed.\n- Strict SwiftLint passed for every changed Swift file.\n- git diff --check passed.