### PR TITLE
Add runtime environment diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,23 @@ if pcc.isRunnableInCurrentProcess {
 }
 ```
 
+### Environment Diagnostics
+
+`FoundationModelEnvironmentDiagnostics` combines runtime availability with observable OS, build, simulator, locale, device, and boot-volume facts. It returns typed issues and recovery actions for known blockers such as a disabled Apple Intelligence setting, an ineligible device, missing PCC entitlement, external macOS boot volume, or mismatched SDK and Simulator versions.
+
+```swift
+let report = FoundationModelEnvironmentDiagnostics().report(for: .onDevice)
+
+if report.canAttemptRequest {
+    // The request result is still authoritative.
+    runGeneration()
+} else {
+    present(report.issues)
+}
+```
+
+The report states its blind spots. Public APIs don't expose tool-specific model asset readiness, the simulator host OS version, or reliable VM detection, so diagnostics never infer those states from general model availability.
+
 ### Generation Use Cases
 
 Wrap Foundation Models calls in request and result types that are easy to test, serialize, and record.

--- a/Sources/FoundationModelsKit/Models/FoundationModelRuntimeEnvironment.swift
+++ b/Sources/FoundationModelsKit/Models/FoundationModelRuntimeEnvironment.swift
@@ -1,0 +1,194 @@
+import Darwin
+import Foundation
+
+/// Observable process, build, simulator, and boot-volume facts for runtime diagnostics.
+public struct FoundationModelRuntimeEnvironment: Codable, Equatable, Sendable {
+    public enum ProcessKind: String, Codable, Equatable, Sendable {
+        case native
+        case simulator
+    }
+
+    public enum BootVolume: String, Codable, Equatable, Sendable {
+        case `internal`
+        case external
+        case unknown
+    }
+
+    public struct BuildInformation: Codable, Equatable, Sendable {
+        public let xcodeBuild: String?
+        public let sdkName: String?
+        public let sdkBuild: String?
+        public let platformName: String?
+        public let platformVersion: String?
+        public let minimumOperatingSystemVersion: String?
+
+        public init(
+            xcodeBuild: String? = nil,
+            sdkName: String? = nil,
+            sdkBuild: String? = nil,
+            platformName: String? = nil,
+            platformVersion: String? = nil,
+            minimumOperatingSystemVersion: String? = nil
+        ) {
+            self.xcodeBuild = xcodeBuild
+            self.sdkName = sdkName
+            self.sdkBuild = sdkBuild
+            self.platformName = platformName
+            self.platformVersion = platformVersion
+            self.minimumOperatingSystemVersion = minimumOperatingSystemVersion
+        }
+    }
+
+    public struct SimulatorInformation: Codable, Equatable, Sendable {
+        public let deviceName: String?
+        public let modelIdentifier: String?
+        public let runtimeVersion: String?
+        public let runtimeBuild: String?
+
+        public init(
+            deviceName: String? = nil,
+            modelIdentifier: String? = nil,
+            runtimeVersion: String? = nil,
+            runtimeBuild: String? = nil
+        ) {
+            self.deviceName = deviceName
+            self.modelIdentifier = modelIdentifier
+            self.runtimeVersion = runtimeVersion
+            self.runtimeBuild = runtimeBuild
+        }
+    }
+
+    public let operatingSystemName: String
+    public let operatingSystemVersion: String
+    public let operatingSystemBuild: String?
+    public let deviceModelIdentifier: String?
+    public let localeIdentifier: String
+    public let processKind: ProcessKind
+    public let bootVolume: BootVolume
+    public let build: BuildInformation
+    public let simulator: SimulatorInformation?
+
+    public init(
+        operatingSystemName: String,
+        operatingSystemVersion: String,
+        operatingSystemBuild: String? = nil,
+        deviceModelIdentifier: String? = nil,
+        localeIdentifier: String,
+        processKind: ProcessKind,
+        bootVolume: BootVolume = .unknown,
+        build: BuildInformation = BuildInformation(),
+        simulator: SimulatorInformation? = nil
+    ) {
+        self.operatingSystemName = operatingSystemName
+        self.operatingSystemVersion = operatingSystemVersion
+        self.operatingSystemBuild = operatingSystemBuild
+        self.deviceModelIdentifier = deviceModelIdentifier
+        self.localeIdentifier = localeIdentifier
+        self.processKind = processKind
+        self.bootVolume = bootVolume
+        self.build = build
+        self.simulator = simulator
+    }
+
+    public static var current: Self {
+        capture()
+    }
+
+    /// Captures values exposed to the running process. It doesn't probe model or tool assets.
+    public static func capture(
+        bundle: Bundle = .main,
+        locale: Locale = .current
+    ) -> Self {
+        let processInfo = ProcessInfo.processInfo
+        let version = processInfo.operatingSystemVersion
+        let environment = processInfo.environment
+        let versionString = "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+        let build = BuildInformation(
+            xcodeBuild: bundleString("DTXcodeBuild", in: bundle),
+            sdkName: bundleString("DTSDKName", in: bundle),
+            sdkBuild: bundleString("DTSDKBuild", in: bundle),
+            platformName: bundleString("DTPlatformName", in: bundle),
+            platformVersion: bundleString("DTPlatformVersion", in: bundle),
+            minimumOperatingSystemVersion: bundleString("MinimumOSVersion", in: bundle)
+                ?? bundleString("LSMinimumSystemVersion", in: bundle)
+        )
+
+        #if targetEnvironment(simulator)
+        let processKind = ProcessKind.simulator
+        let simulator = SimulatorInformation(
+            deviceName: environment["SIMULATOR_DEVICE_NAME"],
+            modelIdentifier: environment["SIMULATOR_MODEL_IDENTIFIER"],
+            runtimeVersion: environment["SIMULATOR_RUNTIME_VERSION"],
+            runtimeBuild: environment["SIMULATOR_RUNTIME_BUILD_VERSION"]
+        )
+        #else
+        let processKind = ProcessKind.native
+        let simulator: SimulatorInformation? = nil
+        #endif
+
+        return Self(
+            operatingSystemName: operatingSystemName,
+            operatingSystemVersion: versionString,
+            operatingSystemBuild: systemString(for: "kern.osversion"),
+            deviceModelIdentifier: environment["SIMULATOR_MODEL_IDENTIFIER"]
+                ?? nativeModelIdentifier,
+            localeIdentifier: locale.identifier,
+            processKind: processKind,
+            bootVolume: bootVolume,
+            build: build,
+            simulator: simulator
+        )
+    }
+
+    private static var operatingSystemName: String {
+        #if os(macOS)
+        "macOS"
+        #elseif os(iOS)
+        "iOS"
+        #elseif os(visionOS)
+        "visionOS"
+        #else
+        "Apple OS"
+        #endif
+    }
+
+    private static var nativeModelIdentifier: String? {
+        #if os(macOS)
+        systemString(for: "hw.model")
+        #else
+        systemString(for: "hw.machine")
+        #endif
+    }
+
+    private static var bootVolume: BootVolume {
+        #if os(macOS)
+        let keys: Set<URLResourceKey> = [.volumeIsInternalKey]
+        guard let values = try? URL(fileURLWithPath: "/").resourceValues(forKeys: keys),
+              let isInternal = values.volumeIsInternal else {
+            return .unknown
+        }
+        return isInternal ? .internal : .external
+        #else
+        return .internal
+        #endif
+    }
+
+    private static func bundleString(_ key: String, in bundle: Bundle) -> String? {
+        bundle.infoDictionary?[key] as? String
+    }
+
+    private static func systemString(for name: String) -> String? {
+        var size = 0
+        guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else {
+            return nil
+        }
+
+        var buffer = [CChar](repeating: 0, count: size)
+        let status = buffer.withUnsafeMutableBytes { bytes in
+            sysctlbyname(name, bytes.baseAddress, &size, nil, 0)
+        }
+        guard status == 0 else { return nil }
+        let bytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(bytes: bytes, encoding: .utf8)
+    }
+}

--- a/Sources/FoundationModelsKit/Results/FoundationModelEnvironmentIssue.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelEnvironmentIssue.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// One known environment blocker with machine-readable recovery actions.
+public struct FoundationModelEnvironmentIssue: Codable, Equatable, Sendable {
+    public enum Code: String, Codable, Equatable, Sendable {
+        case unsupportedOperatingSystem = "unsupported_operating_system"
+        case unsupportedToolchain = "unsupported_toolchain"
+        case deviceNotEligible = "device_not_eligible"
+        case appleIntelligenceNotEnabled = "apple_intelligence_not_enabled"
+        case modelNotReady = "model_not_ready"
+        case systemNotReady = "system_not_ready"
+        case missingPrivateCloudEntitlement = "missing_private_cloud_entitlement"
+        case externalBootVolume = "external_boot_volume"
+        case deploymentTargetBelowRequired = "deployment_target_below_required"
+        case sdkRuntimeVersionMismatch = "sdk_runtime_version_mismatch"
+        case unknownRuntimeState = "unknown_runtime_state"
+    }
+
+    public enum Severity: String, Codable, Equatable, Sendable {
+        case warning
+        case error
+    }
+
+    public enum Action: String, Codable, Equatable, Sendable {
+        case useSupportedOperatingSystem = "use_supported_operating_system"
+        case useSupportedToolchain = "use_supported_toolchain"
+        case useEligibleDevice = "use_eligible_device"
+        case enableAppleIntelligence = "enable_apple_intelligence"
+        case waitForModelAssets = "wait_for_model_assets"
+        case addPrivateCloudComputeEntitlement = "add_private_cloud_compute_entitlement"
+        case bootFromInternalVolume = "boot_from_internal_volume"
+        case alignXcodeSDKSimulatorAndHost = "align_xcode_sdk_simulator_and_host"
+        case inspectRuntimeStatus = "inspect_runtime_status"
+        case collectSysdiagnoseAndFileFeedback = "collect_sysdiagnose_and_file_feedback"
+    }
+
+    public let code: Code
+    public let severity: Severity
+    public let actions: [Action]
+
+    public init(code: Code, severity: Severity, actions: [Action]) {
+        self.code = code
+        self.severity = severity
+        self.actions = actions
+    }
+}

--- a/Sources/FoundationModelsKit/Results/FoundationModelEnvironmentReport.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelEnvironmentReport.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Structured preflight facts and known blockers for one requested runtime.
+public struct FoundationModelEnvironmentReport: Codable, Equatable, Sendable {
+    public enum Limitation: String, Codable, Equatable, Sendable {
+        case toolSpecificAssetReadinessNotExposed = "tool_specific_asset_readiness_not_exposed"
+        case simulatorHostOperatingSystemNotExposed = "simulator_host_operating_system_not_exposed"
+        case virtualizationStateNotExposed = "virtualization_state_not_exposed"
+    }
+
+    public let capturedAt: Date
+    public let environment: FoundationModelRuntimeEnvironment
+    public let runtimeStatus: FoundationModelRuntimeStatus
+    public let issues: [FoundationModelEnvironmentIssue]
+    public let limitations: [Limitation]
+
+    /// True when public preflight signals show no blocker. The request itself remains authoritative.
+    public var canAttemptRequest: Bool {
+        runtimeStatus.isRunnableInCurrentProcess
+            && !issues.contains { $0.severity == .error }
+    }
+
+    public init(
+        capturedAt: Date,
+        environment: FoundationModelRuntimeEnvironment,
+        runtimeStatus: FoundationModelRuntimeStatus,
+        issues: [FoundationModelEnvironmentIssue],
+        limitations: [Limitation]
+    ) {
+        self.capturedAt = capturedAt
+        self.environment = environment
+        self.runtimeStatus = runtimeStatus
+        self.issues = issues
+        self.limitations = limitations
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelEnvironmentDiagnostics.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelEnvironmentDiagnostics.swift
@@ -68,6 +68,13 @@ public struct FoundationModelEnvironmentDiagnostics: Sendable {
     ) -> FoundationModelEnvironmentIssue? {
         guard !status.isRunnableInCurrentProcess else { return nil }
 
+        if status.runtime == .privateCloudCompute, status.authorization == .missing {
+            return issue(
+                .missingPrivateCloudEntitlement,
+                actions: [.addPrivateCloudComputeEntitlement]
+            )
+        }
+
         switch status.reason {
         case .unsupportedOperatingSystem:
             return issue(.unsupportedOperatingSystem, actions: [.useSupportedOperatingSystem])

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelEnvironmentDiagnostics.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelEnvironmentDiagnostics.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+/// Builds a structured Foundation Models preflight report from public runtime and process facts.
+public struct FoundationModelEnvironmentDiagnostics: Sendable {
+    private let inspector: any FoundationModelRuntimeInspecting
+    private let environment: FoundationModelRuntimeEnvironment
+
+    public init(
+        inspector: any FoundationModelRuntimeInspecting = FoundationModelsRuntimeInspector(),
+        environment: FoundationModelRuntimeEnvironment = .current
+    ) {
+        self.inspector = inspector
+        self.environment = environment
+    }
+
+    public func report(
+        for runtime: FoundationModelRuntime,
+        capturedAt: Date = Date()
+    ) -> FoundationModelEnvironmentReport {
+        let status = inspector.status(for: runtime)
+        return FoundationModelEnvironmentReport(
+            capturedAt: capturedAt,
+            environment: environment,
+            runtimeStatus: status,
+            issues: environmentIssues(for: status),
+            limitations: limitations()
+        )
+    }
+
+    private func environmentIssues(
+        for status: FoundationModelRuntimeStatus
+    ) -> [FoundationModelEnvironmentIssue] {
+        var issues: [FoundationModelEnvironmentIssue] = []
+
+        if environment.bootVolume == .external, environment.operatingSystemName == "macOS" {
+            issues.append(issue(
+                .externalBootVolume,
+                actions: [.bootFromInternalVolume]
+            ))
+        }
+
+        if let minimumVersion = environment.build.minimumOperatingSystemVersion,
+           Self.version(minimumVersion, isBelow: (26, 0)) {
+            issues.append(issue(
+                .deploymentTargetBelowRequired,
+                actions: [.useSupportedOperatingSystem]
+            ))
+        }
+
+        if environment.processKind == .simulator,
+           let sdkVersion = environment.build.platformVersion,
+           let runtimeVersion = environment.simulator?.runtimeVersion,
+           !Self.versionsMatch(sdkVersion, runtimeVersion) {
+            issues.append(issue(
+                .sdkRuntimeVersionMismatch,
+                actions: [.alignXcodeSDKSimulatorAndHost]
+            ))
+        }
+
+        if let statusIssue = runtimeIssue(for: status) {
+            issues.append(statusIssue)
+        }
+        return issues
+    }
+
+    private func runtimeIssue(
+        for status: FoundationModelRuntimeStatus
+    ) -> FoundationModelEnvironmentIssue? {
+        guard !status.isRunnableInCurrentProcess else { return nil }
+
+        switch status.reason {
+        case .unsupportedOperatingSystem:
+            return issue(.unsupportedOperatingSystem, actions: [.useSupportedOperatingSystem])
+        case .unsupportedToolchain:
+            return issue(.unsupportedToolchain, actions: [.useSupportedToolchain])
+        case .deviceNotEligible:
+            return issue(.deviceNotEligible, actions: [.useEligibleDevice])
+        case .appleIntelligenceNotEnabled:
+            return issue(.appleIntelligenceNotEnabled, actions: [.enableAppleIntelligence])
+        case .modelNotReady:
+            return issue(
+                .modelNotReady,
+                severity: .warning,
+                actions: [
+                    .waitForModelAssets,
+                    .alignXcodeSDKSimulatorAndHost,
+                    .collectSysdiagnoseAndFileFeedback
+                ]
+            )
+        case .systemNotReady:
+            return issue(
+                .systemNotReady,
+                severity: .warning,
+                actions: [
+                    .waitForModelAssets,
+                    .alignXcodeSDKSimulatorAndHost,
+                    .collectSysdiagnoseAndFileFeedback
+                ]
+            )
+        case .missingEntitlement:
+            return issue(
+                .missingPrivateCloudEntitlement,
+                actions: [.addPrivateCloudComputeEntitlement]
+            )
+        case .unknown, .none:
+            return issue(
+                .unknownRuntimeState,
+                severity: .warning,
+                actions: [.inspectRuntimeStatus, .collectSysdiagnoseAndFileFeedback]
+            )
+        }
+    }
+
+    private func limitations() -> [FoundationModelEnvironmentReport.Limitation] {
+        var values: [FoundationModelEnvironmentReport.Limitation] = [
+            .toolSpecificAssetReadinessNotExposed
+        ]
+        if environment.processKind == .simulator {
+            values.append(.simulatorHostOperatingSystemNotExposed)
+        }
+        if environment.operatingSystemName == "macOS" {
+            values.append(.virtualizationStateNotExposed)
+        }
+        return values
+    }
+
+    private func issue(
+        _ code: FoundationModelEnvironmentIssue.Code,
+        severity: FoundationModelEnvironmentIssue.Severity = .error,
+        actions: [FoundationModelEnvironmentIssue.Action]
+    ) -> FoundationModelEnvironmentIssue {
+        FoundationModelEnvironmentIssue(
+            code: code,
+            severity: severity,
+            actions: actions
+        )
+    }
+
+    private static func versionsMatch(_ lhs: String, _ rhs: String) -> Bool {
+        let left = versionComponents(lhs)
+        let right = versionComponents(rhs)
+        guard left.count >= 2, right.count >= 2 else { return true }
+        return left.prefix(2).elementsEqual(right.prefix(2))
+    }
+
+    private static func version(_ value: String, isBelow minimum: (Int, Int)) -> Bool {
+        let components = versionComponents(value)
+        guard let major = components.first else { return false }
+        let minor = components.count > 1 ? components[1] : 0
+        return (major, minor) < minimum
+    }
+
+    private static func versionComponents(_ value: String) -> [Int] {
+        value.split(separator: ".").compactMap { component in
+            Int(component.prefix { $0.isNumber })
+        }
+    }
+}

--- a/Tests/FoundationModelsKitTests/FoundationModelEnvironmentDiagnosticsTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelEnvironmentDiagnosticsTests.swift
@@ -49,6 +49,22 @@ struct EnvironmentDiagnosticsTests {
         #expect(issue.actions == [.addPrivateCloudComputeEntitlement])
     }
 
+    @Test("A missing PCC entitlement takes precedence over a broader availability reason")
+    func prioritizesMissingEntitlement() throws {
+        let report = diagnostics(
+            status: FoundationModelRuntimeStatus(
+                runtime: .privateCloudCompute,
+                isAvailable: false,
+                authorization: .missing,
+                reason: .systemNotReady
+            )
+        ).report(for: .privateCloudCompute)
+        let issue = try #require(report.issues.last)
+
+        #expect(issue.code == .missingPrivateCloudEntitlement)
+        #expect(issue.actions == [.addPrivateCloudComputeEntitlement])
+    }
+
     @Test("External macOS boot volumes remain visible even when availability says available")
     func reportsExternalBootVolume() {
         let environment = FoundationModelRuntimeEnvironment(

--- a/Tests/FoundationModelsKitTests/FoundationModelEnvironmentDiagnosticsTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelEnvironmentDiagnosticsTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+@testable import FoundationModelsKit
+
+@Suite("Foundation Model environment diagnostics")
+struct EnvironmentDiagnosticsTests {
+    @Test("A runnable native environment permits an authoritative request attempt")
+    func runnableEnvironment() {
+        let report = diagnostics(
+            status: FoundationModelRuntimeStatus(runtime: .onDevice, isAvailable: true)
+        ).report(
+            for: .onDevice,
+            capturedAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        #expect(report.canAttemptRequest)
+        #expect(report.issues.isEmpty)
+        #expect(report.limitations.contains(.toolSpecificAssetReadinessNotExposed))
+    }
+
+    @Test("Runtime reasons map to typed actions")
+    func mapsRuntimeReason() throws {
+        let report = diagnostics(
+            status: FoundationModelRuntimeStatus(
+                runtime: .onDevice,
+                isAvailable: false,
+                reason: .appleIntelligenceNotEnabled
+            )
+        ).report(for: .onDevice)
+        let issue = try #require(report.issues.last)
+
+        #expect(!report.canAttemptRequest)
+        #expect(issue.code == .appleIntelligenceNotEnabled)
+        #expect(issue.actions == [.enableAppleIntelligence])
+    }
+
+    @Test("PCC reports a missing managed entitlement")
+    func reportsMissingEntitlement() throws {
+        let report = diagnostics(
+            status: FoundationModelRuntimeStatus(
+                runtime: .privateCloudCompute,
+                isAvailable: true,
+                authorization: .missing
+            )
+        ).report(for: .privateCloudCompute)
+        let issue = try #require(report.issues.last)
+
+        #expect(issue.code == .missingPrivateCloudEntitlement)
+        #expect(issue.actions == [.addPrivateCloudComputeEntitlement])
+    }
+
+    @Test("External macOS boot volumes remain visible even when availability says available")
+    func reportsExternalBootVolume() {
+        let environment = FoundationModelRuntimeEnvironment(
+            operatingSystemName: "macOS",
+            operatingSystemVersion: "26.6",
+            localeIdentifier: "en_US",
+            processKind: .native,
+            bootVolume: .external
+        )
+        let report = FoundationModelEnvironmentDiagnostics(
+            inspector: StubRuntimeInspector(
+                status: FoundationModelRuntimeStatus(runtime: .onDevice, isAvailable: true)
+            ),
+            environment: environment
+        ).report(for: .onDevice)
+
+        #expect(!report.canAttemptRequest)
+        #expect(report.issues.map(\.code) == [.externalBootVolume])
+        #expect(report.limitations.contains(.virtualizationStateNotExposed))
+    }
+
+    @Test("Simulator SDK and runtime versions must match through minor version")
+    func reportsSimulatorVersionMismatch() {
+        let environment = FoundationModelRuntimeEnvironment(
+            operatingSystemName: "iOS",
+            operatingSystemVersion: "26.1",
+            localeIdentifier: "en_US",
+            processKind: .simulator,
+            build: .init(platformVersion: "26.2"),
+            simulator: .init(runtimeVersion: "26.1")
+        )
+        let report = FoundationModelEnvironmentDiagnostics(
+            inspector: StubRuntimeInspector(
+                status: FoundationModelRuntimeStatus(runtime: .onDevice, isAvailable: true)
+            ),
+            environment: environment
+        ).report(for: .onDevice)
+
+        #expect(report.issues.map(\.code) == [.sdkRuntimeVersionMismatch])
+        #expect(report.limitations.contains(.simulatorHostOperatingSystemNotExposed))
+    }
+
+    @Test("Reports round-trip observable facts and limitations")
+    func reportRoundTrips() throws {
+        let report = diagnostics(
+            status: FoundationModelRuntimeStatus(
+                runtime: .onDevice,
+                isAvailable: false,
+                reason: .modelNotReady
+            )
+        ).report(
+            for: .onDevice,
+            capturedAt: Date(timeIntervalSince1970: 1_000)
+        )
+
+        let data = try JSONEncoder().encode(report)
+        let decoded = try JSONDecoder().decode(
+            FoundationModelEnvironmentReport.self,
+            from: data
+        )
+
+        #expect(decoded == report)
+        #expect(decoded.issues.first?.severity == .warning)
+    }
+
+    private func diagnostics(
+        status: FoundationModelRuntimeStatus
+    ) -> FoundationModelEnvironmentDiagnostics {
+        FoundationModelEnvironmentDiagnostics(
+            inspector: StubRuntimeInspector(status: status),
+            environment: FoundationModelRuntimeEnvironment(
+                operatingSystemName: "iOS",
+                operatingSystemVersion: "26.6",
+                localeIdentifier: "en_US",
+                processKind: .native,
+                bootVolume: .internal,
+                build: .init(minimumOperatingSystemVersion: "26.0")
+            )
+        )
+    }
+}
+
+private struct StubRuntimeInspector: FoundationModelRuntimeInspecting {
+    let status: FoundationModelRuntimeStatus
+
+    func status(for runtime: FoundationModelRuntime) -> FoundationModelRuntimeStatus {
+        _ = runtime
+        return status
+    }
+
+    func quotaUsage(for runtime: FoundationModelRuntime) -> FoundationModelQuotaUsage {
+        FoundationModelQuotaUsage(runtime: runtime, status: .notApplicable)
+    }
+}


### PR DESCRIPTION
## Summary\n\nAdd FoundationModelEnvironmentDiagnostics with Codable reports for runtime status, OS and build metadata, device and locale, Simulator metadata, deployment target, and macOS boot-volume state.\n\nKnown blockers map to typed codes and app-localizable recovery actions. The report covers disabled Apple Intelligence, device eligibility, model or system readiness, PCC entitlement, external boot volumes, old deployment targets, and SDK to Simulator version mismatches.\n\nThe report also names what public APIs cannot inspect: tool-specific model assets, the Simulator host OS version, and reliable VM state. canAttemptRequest means no known preflight blocker; the actual request remains authoritative.\n\n## Validation\n\n- Xcode 26.6 RC 2: 190 tests passed in 31 suites.\n- Xcode 27 beta 5: tools, core, and evaluation test runs passed.\n- Strict SwiftLint passed for every changed Swift file.\n- git diff --check passed.\n\nApple forum evidence: https://developer.apple.com/forums/thread/787445