### PR TITLE
Separate app authorization from user confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ do {
 
 `FoundationModelToolExecutionPolicy` owns one turn's tool budget. It validates generated JSON before app code runs, detects repeated `(tool, arguments)` calls, and caps calls, repairs, elapsed time, and actual output tokens.
 
-The validator supports required properties, string or numeric enums, integer and number ranges, arrays, `anyOf`, and discriminated unions. Policy decisions return typed `loopDetected`, `invalidArguments`, or `budgetExceeded` results. A side-effecting call must choose app-owned confirmation or a nonempty idempotency key.
+The validator supports required properties, string or numeric enums, integer and number ranges, arrays, `anyOf`, and discriminated unions. Policy decisions return typed `loopDetected`, `invalidArguments`, `budgetExceeded`, `authorizationDenied`, or `confirmationRequired` results. A side-effecting call must choose app-owned confirmation or a nonempty idempotency key.
 
 ```swift
 let policy = FoundationModelToolExecutionPolicy(
@@ -240,6 +240,45 @@ let result = try await policy.execute(
     try await lookup(arguments)
 }
 ```
+
+#### App Authorization and User Confirmation
+
+Platform permission, app authorization, and user confirmation are separate decisions. A system framework may permit access while the current actor, account, resource, or capability scope remains unauthorized. Confirmation approves one proposed side effect; it never grants that underlying authorization.
+
+Pass a `FoundationModelToolExecutionAuthorizing` implementation when a tool needs an app-owned policy check. The implementation can capture current account and resource state without exposing those domain concepts to the model or the package.
+
+```swift
+struct ResourceAuthorizer: FoundationModelToolExecutionAuthorizing {
+    let accessStore: AccessStore
+
+    func authorize(
+        _ request: FoundationModelToolAuthorizationRequest,
+        arguments: FoundationModelToolValue
+    ) async -> FoundationModelToolAuthorizationDecision {
+        guard await accessStore.canExecute(tool: request.toolName, arguments: arguments) else {
+            return .denied(.init(code: "resource_access_denied"))
+        }
+        return .allowed
+    }
+}
+
+let result = try await policy.execute(
+    tool: "update-record",
+    arguments: generatedArguments,
+    schema: toolSchema,
+    effect: .sideEffect(.confirmation),
+    authorizer: ResourceAuthorizer(accessStore: accessStore),
+    confirmer: confirmationProvider
+) {
+    try await updateRecord(generatedArguments)
+}
+```
+
+For a confirmed side effect, the policy checks authorization before presenting confirmation and re-evaluates it immediately before execution. This catches access revoked while confirmation UI is visible. Read-only and idempotent calls are checked immediately before execution. Denials carry an app-defined, non-sensitive code and never run tool code.
+
+The authorizer supervises model-directed execution but does not replace authorization enforcement inside the app service that performs the operation. The service remains authoritative for current access and resource invariants.
+
+Omitting the authorizer preserves existing behavior and means the host app has determined that no additional app-owned authorization gate is required for that call.
 
 ### Typed Tool Result Routing
 

--- a/Sources/FoundationModelEvaluation/FoundationModelToolCallEvent+Invocation.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelToolCallEvent+Invocation.swift
@@ -12,7 +12,8 @@ public extension FoundationModelToolCallEvent {
             eventOutcome = .succeeded
         case .failed:
             eventOutcome = .failed
-        case .loopDetected, .invalidArguments, .budgetExceeded, .confirmationRequired:
+        case .loopDetected, .invalidArguments, .budgetExceeded, .authorizationDenied,
+             .confirmationRequired:
             eventOutcome = .rejected
         }
         self.init(

--- a/Sources/FoundationModelsKit/Results/FoundationModelToolExecutionResult.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelToolExecutionResult.swift
@@ -17,6 +17,7 @@ public enum FoundationModelToolExecutionResult<Output: Sendable>: Sendable {
     case loopDetected(FoundationModelToolLoop)
     case invalidArguments([FoundationModelToolArgumentIssue])
     case budgetExceeded(FoundationModelToolBudgetExceeded)
+    case authorizationDenied(FoundationModelToolAuthorizationDenial)
     case confirmationRequired(FoundationModelToolConfirmationRequest)
 }
 

--- a/Sources/FoundationModelsKit/Results/FoundationModelToolInvocation.swift
+++ b/Sources/FoundationModelsKit/Results/FoundationModelToolInvocation.swift
@@ -7,6 +7,7 @@ public struct FoundationModelToolInvocation<Outcome: Sendable>: Sendable {
         case loopDetected = "loop_detected"
         case invalidArguments = "invalid_arguments"
         case budgetExceeded = "budget_exceeded"
+        case authorizationDenied = "authorization_denied"
         case confirmationRequired = "confirmation_required"
         case failed
     }

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelToolAuthorization.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelToolAuthorization.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// The point in tool execution at which the app re-evaluates authorization.
+public enum FoundationModelToolAuthorizationPhase: String, Codable, Equatable, Sendable {
+    /// Before presenting a confirmation request for a side effect.
+    case beforeConfirmation
+
+    /// Immediately before app-owned tool code executes.
+    case beforeExecution
+}
+
+/// A privacy-safe request for an app-owned authorization decision.
+///
+/// Generated arguments are delivered separately to the authorizer so apps can avoid retaining
+/// sensitive values in authorization logs.
+public struct FoundationModelToolAuthorizationRequest: Equatable, Sendable {
+    public let toolName: String
+    public let callFingerprint: String
+    public let phase: FoundationModelToolAuthorizationPhase
+
+    public init(
+        toolName: String,
+        callFingerprint: String,
+        phase: FoundationModelToolAuthorizationPhase
+    ) {
+        self.toolName = toolName
+        self.callFingerprint = callFingerprint
+        self.phase = phase
+    }
+}
+
+/// App-defined, non-sensitive evidence explaining why a tool call was not authorized.
+public struct FoundationModelToolAuthorizationDenial: Equatable, Sendable {
+    public let code: String
+
+    public init(code: String = "denied") {
+        let normalizedCode = code.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.code = normalizedCode.isEmpty ? "denied" : normalizedCode
+    }
+}
+
+/// The app-owned authorization decision for a generated tool call.
+public enum FoundationModelToolAuthorizationDecision: Equatable, Sendable {
+    case allowed
+    case denied(FoundationModelToolAuthorizationDenial)
+}
+
+/// Re-evaluates whether the current app context may execute a generated tool call.
+///
+/// Authorization is distinct from platform permission and user confirmation. Implementations can
+/// capture app-specific actor, capability, resource, and revocation state without exposing those
+/// domain concepts to the model or this package. This hook supervises model-directed execution; it
+/// does not replace authorization enforcement inside the app service that performs the operation.
+public protocol FoundationModelToolExecutionAuthorizing: Sendable {
+    func authorize(
+        _ request: FoundationModelToolAuthorizationRequest,
+        arguments: FoundationModelToolValue
+    ) async -> FoundationModelToolAuthorizationDecision
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelToolExecutionPolicy.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelToolExecutionPolicy.swift
@@ -63,6 +63,7 @@ public actor FoundationModelToolExecutionPolicy {
         schema: FoundationModelToolSchema,
         attempt: FoundationModelToolExecutionAttempt = .initial,
         effect: FoundationModelToolEffect = .readOnly,
+        authorizer: (any FoundationModelToolExecutionAuthorizing)? = nil,
         confirmer: (any FoundationModelToolExecutionConfirming)? = nil,
         outputTokenEstimator: OutputTokenEstimator<Output>? = nil,
         operation: @escaping @Sendable () async throws -> Output
@@ -110,6 +111,15 @@ public actor FoundationModelToolExecutionPolicy {
         case .readOnly:
             break
         case .sideEffect(.confirmation):
+            if let denial = try await authorizationDenial(
+                for: identity,
+                callFingerprint: callFingerprint,
+                phase: .beforeConfirmation,
+                authorizer: authorizer,
+                arguments: arguments
+            ) {
+                return .authorizationDenied(denial)
+            }
             let request = FoundationModelToolConfirmationRequest(
                 toolName: toolName,
                 callFingerprint: callFingerprint
@@ -141,6 +151,16 @@ public actor FoundationModelToolExecutionPolicy {
                 ])
             }
             reservedIdempotencyKeys[scopedKey] = identity
+        }
+
+        if let denial = try await authorizationDenial(
+            for: identity,
+            callFingerprint: callFingerprint,
+            phase: .beforeExecution,
+            authorizer: authorizer,
+            arguments: arguments
+        ) {
+            return .authorizationDenied(denial)
         }
 
         try Task.checkCancellation()
@@ -181,6 +201,33 @@ public actor FoundationModelToolExecutionPolicy {
         }
 
         return .succeeded(output, usage: usage(), outputTokenCount: outputTokenCount)
+    }
+
+    private func authorizationDenial(
+        for identity: CallIdentity,
+        callFingerprint: String,
+        phase: FoundationModelToolAuthorizationPhase,
+        authorizer: (any FoundationModelToolExecutionAuthorizing)?,
+        arguments: FoundationModelToolValue
+    ) async throws -> FoundationModelToolAuthorizationDenial? {
+        guard let authorizer else {
+            return nil
+        }
+
+        let request = FoundationModelToolAuthorizationRequest(
+            toolName: identity.toolName,
+            callFingerprint: callFingerprint,
+            phase: phase
+        )
+        let decision = await authorizer.authorize(request, arguments: arguments)
+        try Task.checkCancellation()
+
+        switch decision {
+        case .allowed:
+            return nil
+        case .denied(let denial):
+            return denial
+        }
     }
 
     private func releasePendingConfirmation(

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelToolResultRouter.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelToolResultRouter.swift
@@ -66,6 +66,14 @@ public actor FoundationModelToolResultRouter<Outcome: Sendable> {
                 status: .budgetExceeded,
                 recordedAt: recordedAt
             )
+        case .authorizationDenied:
+            return try appendPolicyDecision(
+                toolName: toolName,
+                arguments: arguments,
+                identifier: identifier,
+                status: .authorizationDenied,
+                recordedAt: recordedAt
+            )
         case .confirmationRequired:
             return try appendPolicyDecision(
                 toolName: toolName,

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelToolSideEffect.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelToolSideEffect.swift
@@ -26,7 +26,11 @@ public struct FoundationModelToolConfirmationRequest: Equatable, Sendable {
     }
 }
 
-/// Lets the app present its own confirmation UI and authorization policy.
+/// Lets the app present its own confirmation UI for a specific proposed side effect.
+///
+/// Confirmation records a user decision; it does not grant app authorization. Pass a separate
+/// ``FoundationModelToolExecutionAuthorizing`` implementation to the execution policy when the
+/// tool requires an app-owned authorization check.
 public protocol FoundationModelToolExecutionConfirming: Sendable {
     func confirm(
         _ request: FoundationModelToolConfirmationRequest,

--- a/Tests/FoundationModelEvaluationTests/FoundationModelToolCallEventInvocationTests.swift
+++ b/Tests/FoundationModelEvaluationTests/FoundationModelToolCallEventInvocationTests.swift
@@ -17,8 +17,17 @@ struct ToolCallEventInvocationTests {
             arguments: .object([:]),
             failure: FoundationModelErrorProjection(category: .networkFailure)
         )
+        let authorizationDenial = try await router.record(
+            tool: "contacts",
+            arguments: .object([:]),
+            result: FoundationModelToolExecutionResult<String>.authorizationDenied(
+                FoundationModelToolAuthorizationDenial(code: "access_revoked")
+            ),
+            mapSuccess: { $0 }
+        )
 
         #expect(FoundationModelToolCallEvent(invocation: success).outcome == .succeeded)
         #expect(FoundationModelToolCallEvent(invocation: failure).outcome == .failed)
+        #expect(FoundationModelToolCallEvent(invocation: authorizationDenial).outcome == .rejected)
     }
 }

--- a/Tests/FoundationModelsKitTests/FoundationModelToolExecutionPolicyTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelToolExecutionPolicyTests.swift
@@ -195,8 +195,83 @@ struct FoundationModelToolExecutionPolicyTests {
         #expect(issues.first?.code == .invalidIdempotencyKey)
     }
 
+    @Test("Authorization denial prevents read-only tool execution")
+    func deniesUnauthorizedRead() async throws {
+        let denial = FoundationModelToolAuthorizationDenial(code: "resource_access_revoked")
+        let authorizer = ScriptedAuthorizer([.denied(denial)])
+        let probe = ToolOperationProbe()
+        let policy = FoundationModelToolExecutionPolicy()
+
+        let result = try await policy.execute(
+            tool: "private-record",
+            arguments: .object([:]),
+            schema: FoundationModelToolSchema(type: .object),
+            authorizer: authorizer
+        ) {
+            await probe.recordExecution()
+            return "unreachable"
+        }
+
+        #expect(result == .authorizationDenied(denial))
+        #expect(await probe.executionCount == 0)
+        #expect(await authorizer.phases() == [.beforeExecution])
+    }
+
+    @Test("Authorization denial does not present confirmation")
+    func deniesBeforeConfirmation() async throws {
+        let denial = FoundationModelToolAuthorizationDenial(code: "capability_not_granted")
+        let authorizer = ScriptedAuthorizer([.denied(denial)])
+        let confirmer = ApprovingConfirmer()
+        let probe = ToolOperationProbe()
+        let policy = FoundationModelToolExecutionPolicy()
+
+        let result = try await policy.execute(
+            tool: "delete",
+            arguments: .object([:]),
+            schema: FoundationModelToolSchema(type: .object),
+            effect: .sideEffect(.confirmation),
+            authorizer: authorizer,
+            confirmer: confirmer
+        ) {
+            await probe.recordExecution()
+            return true
+        }
+
+        #expect(result == .authorizationDenied(denial))
+        #expect(await authorizer.phases() == [.beforeConfirmation])
+        #expect(await confirmer.confirmationCount == 0)
+        #expect(await probe.executionCount == 0)
+    }
+
+    @Test("Authorization is re-evaluated after confirmation")
+    func reauthorizesAfterConfirmation() async throws {
+        let denial = FoundationModelToolAuthorizationDenial(code: "authorization_revoked")
+        let authorizer = ScriptedAuthorizer([.allowed, .denied(denial)])
+        let confirmer = ApprovingConfirmer()
+        let probe = ToolOperationProbe()
+        let policy = FoundationModelToolExecutionPolicy()
+
+        let result = try await policy.execute(
+            tool: "save",
+            arguments: .object([:]),
+            schema: FoundationModelToolSchema(type: .object),
+            effect: .sideEffect(.confirmation),
+            authorizer: authorizer,
+            confirmer: confirmer
+        ) {
+            await probe.recordExecution()
+            return "unreachable"
+        }
+
+        #expect(result == .authorizationDenied(denial))
+        #expect(await authorizer.phases() == [.beforeConfirmation, .beforeExecution])
+        #expect(await confirmer.confirmationCount == 1)
+        #expect(await probe.executionCount == 0)
+    }
+
     @Test("Approved confirmation executes the side effect once")
     func approvedConfirmationExecutes() async throws {
+        let authorizer = ScriptedAuthorizer([.allowed, .allowed])
         let confirmer = ApprovingConfirmer()
         let policy = FoundationModelToolExecutionPolicy()
         let result = try await policy.execute(
@@ -204,6 +279,7 @@ struct FoundationModelToolExecutionPolicyTests {
             arguments: .object([:]),
             schema: FoundationModelToolSchema(type: .object),
             effect: .sideEffect(.confirmation),
+            authorizer: authorizer,
             confirmer: confirmer,
             operation: { "saved" }
         )
@@ -213,6 +289,7 @@ struct FoundationModelToolExecutionPolicyTests {
             return
         }
         #expect(output == "saved")
+        #expect(await authorizer.phases() == [.beforeConfirmation, .beforeExecution])
         #expect(await confirmer.confirmationCount == 1)
     }
 
@@ -318,5 +395,29 @@ private actor ApprovingConfirmer: FoundationModelToolExecutionConfirming {
     ) -> Bool {
         confirmationCount += 1
         return true
+    }
+}
+
+private actor ScriptedAuthorizer: FoundationModelToolExecutionAuthorizing {
+    private var decisions: [FoundationModelToolAuthorizationDecision]
+    private var requests: [FoundationModelToolAuthorizationRequest] = []
+
+    init(_ decisions: [FoundationModelToolAuthorizationDecision]) {
+        self.decisions = decisions
+    }
+
+    func authorize(
+        _ request: FoundationModelToolAuthorizationRequest,
+        arguments: FoundationModelToolValue
+    ) -> FoundationModelToolAuthorizationDecision {
+        requests.append(request)
+        guard !decisions.isEmpty else {
+            return .denied(FoundationModelToolAuthorizationDenial(code: "missing_test_decision"))
+        }
+        return decisions.removeFirst()
+    }
+
+    func phases() -> [FoundationModelToolAuthorizationPhase] {
+        requests.map(\.phase)
     }
 }

--- a/Tests/FoundationModelsKitTests/FoundationModelToolResultRouterTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelToolResultRouterTests.swift
@@ -93,6 +93,23 @@ struct FoundationModelToolResultRouterTests {
         #expect(await router.routingResult() == .none)
     }
 
+    @Test("Authorization denials remain distinct policy decisions")
+    func recordsAuthorizationDenial() async throws {
+        let router = FoundationModelToolResultRouter<AppOutcome>()
+        let denial = FoundationModelToolAuthorizationDenial(code: "scope_revoked")
+
+        let invocation = try await router.record(
+            tool: "sleep",
+            arguments: .object([:]),
+            result: FoundationModelToolExecutionResult<Int>.authorizationDenied(denial),
+            mapSuccess: { .exercise(minutes: $0) }
+        )
+
+        #expect(invocation.status == .authorizationDenied)
+        #expect(invocation.outcome == nil)
+        #expect(await router.routingResult() == .none)
+    }
+
     @Test("Non-JSON policy rejections retain evidence without raw arguments")
     func recordsNonJSONPolicyRejection() async throws {
         let router = FoundationModelToolResultRouter<AppOutcome>(


### PR DESCRIPTION
## Summary

- separate app-owned authorization from user confirmation in generated tool execution
- add a domain-neutral authorizer with `beforeConfirmation` and `beforeExecution` phases
- return authorization denial as a typed policy result and preserve it through result routing and evaluation events
- document how platform permission, app authorization, and confirmation remain independent trust boundaries

## Safety model

For confirmed side effects, the execution policy now:

1. validates generated arguments
2. checks app authorization before presenting confirmation
3. obtains confirmation for the specific proposed side effect
4. re-evaluates authorization immediately before tool code executes
5. executes only when the current authorization still allows it

Read-only and idempotent calls are authorized immediately before execution. This allows apps to reject access that has expired or been revoked while confirmation UI is visible.

Authorization denial carries an app-defined, non-sensitive code. Generated arguments remain separate from the privacy-safe authorization request. The authorization hook supervises model-directed execution and does not replace enforcement inside the app service performing the operation.

Omitting the authorizer preserves existing execution behavior. Because this adds `authorizationDenied` to public result and invocation enums, downstream exhaustive switches need to handle the new case.

## Tests

- unauthorized read-only calls never execute app code
- unauthorized side effects never present confirmation
- authorization revoked after confirmation prevents execution
- authorized confirmed side effects pass both checks and execute once
- result routing records authorization denial as a distinct policy decision
- evaluation converts authorization denial into a rejected tool-call event

## Validation

- Xcode 26.6: `swift test` — 208 tests in 34 suites passed
- strict SwiftLint on every changed Swift file — 0 violations
- `git diff --check` passed
