### PR TITLE
Add privacy-preserving multimodal requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,25 @@ let result = try await FoundationModelTextGenerationUseCase().execute(request)
 print(result.content)
 ```
 
+On iOS 27 and macOS 27, text-generation requests can include labeled image files through Apple's [multimodal prompting APIs](https://developer.apple.com/documentation/foundationmodels/analyzing-images-with-multimodal-prompting). Labels are stable identifiers the model can use to distinguish attachments. The native `Attachment` bridge is compiler- and availability-gated, so text-only requests remain compatible with OS 26.
+
+```swift
+let image = FoundationModelImageAttachment(
+    label: "receipt",
+    imageURL: receiptURL,
+    orientation: .right
+)
+let request = FoundationModelTextGenerationRequest(
+    prompt: "List the merchant, date, and total shown in this image.",
+    imageAttachments: [image],
+    context: FoundationModelInvocationContext(source: .app)
+)
+
+let result = try await FoundationModelTextGenerationUseCase().execute(request)
+```
+
+Before execution, `FoundationModelsTextGenerator` requires unique nonempty labels, local nonempty image files recognized by Image I/O, at most eight attachments, and at most 20 MiB per attachment. Those package safety budgets are configurable with `FoundationModelImageAttachmentPolicy`; they are not claims about the model's own limits. Image prompting requires the Xcode 27 SDK and an iOS 27 or macOS 27 runtime.
+
 Available use cases include:
 
 - `FoundationModelTextGenerationUseCase`
@@ -287,7 +306,9 @@ let replay = try FoundationModelReplayTextGenerator(cassette: cassette)
 let deterministicResult = try await replay.generateText(for: request)
 ```
 
-Cassettes contain complete prompts, instructions, adapter URLs, and responses. Creating or exporting one is an explicit app decision; the package doesn't redact or persist it automatically. `FoundationModelEvaluationSnapshot` removes run IDs, dates, and latency so checked-in golden comparisons report drift only in stable evaluation fields.
+Cassette format 2 contains complete prompts, instructions, adapter URLs, and responses while remaining able to replay format 1 text-only fixtures. Creating or exporting one is an explicit app decision. Image attachments are the exception: `FoundationModelRecordingTextGenerator` validates each file and records only its label, orientation, Image I/O type, byte count, and SHA-256 digest. It never copies image pixels or local file URLs into a cassette. Replay matches the digest, so identical content can move to a different path. A content digest can still identify predictable or previously known material; treat it as pseudonymous metadata rather than anonymization.
+
+Directly encoding `FoundationModelTextGenerationRequest` preserves executable image file URLs. Use the recording wrapper when exporting fixtures, and apply the same review and storage policy to prompt and response text. `FoundationModelEvaluationSnapshot` removes run IDs, dates, and latency so checked-in golden comparisons report drift only in stable evaluation fields.
 
 ### Tools
 

--- a/Sources/FoundationModelEvaluation/FoundationModelRecordingTextGenerator.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelRecordingTextGenerator.swift
@@ -2,11 +2,13 @@ import Foundation
 import FoundationModelsKit
 
 /// Records explicit text-generation requests and stable outcomes while forwarding to a real provider.
+/// Image paths are replaced with content descriptors before records can be exported.
 public actor FoundationModelRecordingTextGenerator: FoundationModelTextGenerating {
     public typealias ErrorProjector = @Sendable (any Error) -> FoundationModelErrorProjection?
 
     private let base: any FoundationModelTextGenerating
     private let errorProjector: ErrorProjector
+    private let imageAttachmentInspector: FoundationModelImageAttachmentInspector
     private var nextSequence = 0
     private var recordedResults: [FoundationModelTextGenerationRecord] = []
 
@@ -14,13 +16,29 @@ public actor FoundationModelRecordingTextGenerator: FoundationModelTextGeneratin
         base: any FoundationModelTextGenerating,
         errorProjector: @escaping ErrorProjector = FoundationModelErrorProjection.project
     ) {
+        self.init(
+            base: base,
+            imageAttachmentPolicy: .default,
+            errorProjector: errorProjector
+        )
+    }
+
+    public init(
+        base: any FoundationModelTextGenerating,
+        imageAttachmentPolicy: FoundationModelImageAttachmentPolicy,
+        errorProjector: @escaping ErrorProjector = FoundationModelErrorProjection.project
+    ) {
         self.base = base
+        self.imageAttachmentInspector = FoundationModelImageAttachmentInspector(
+            policy: imageAttachmentPolicy
+        )
         self.errorProjector = errorProjector
     }
 
     public func generateText(
         for request: FoundationModelTextGenerationRequest
     ) async throws -> FoundationModelTextGenerationResult {
+        let recordedRequest = try recordingRepresentation(of: request)
         let sequence = nextSequence
         nextSequence += 1
 
@@ -28,21 +46,21 @@ public actor FoundationModelRecordingTextGenerator: FoundationModelTextGeneratin
             let result = try await base.generateText(for: request)
             recordedResults.append(FoundationModelTextGenerationRecord(
                 sequence: sequence,
-                request: request,
+                request: recordedRequest,
                 outcome: .success(result)
             ))
             return result
         } catch is CancellationError {
             recordedResults.append(FoundationModelTextGenerationRecord(
                 sequence: sequence,
-                request: request,
+                request: recordedRequest,
                 outcome: .cancelled
             ))
             throw CancellationError()
         } catch {
             recordedResults.append(FoundationModelTextGenerationRecord(
                 sequence: sequence,
-                request: request,
+                request: recordedRequest,
                 outcome: .failure(
                     errorProjector(error) ?? FoundationModelErrorProjection(category: .unknown)
                 )
@@ -63,6 +81,21 @@ public actor FoundationModelRecordingTextGenerator: FoundationModelTextGeneratin
         FoundationModelTextGenerationCassette(
             fingerprint: fingerprint,
             records: recordedResults
+        )
+    }
+
+    private func recordingRepresentation(
+        of request: FoundationModelTextGenerationRequest
+    ) throws -> FoundationModelTextGenerationRequest {
+        guard !request.imageAttachments.isEmpty else {
+            return request
+        }
+
+        let descriptors = try imageAttachmentInspector.descriptors(
+            for: request.imageAttachments
+        )
+        return request.replacingImageAttachments(
+            with: descriptors.map(FoundationModelImageAttachment.metadataOnly)
         )
     }
 }

--- a/Sources/FoundationModelEvaluation/FoundationModelReplayTextGenerator.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelReplayTextGenerator.swift
@@ -10,16 +10,23 @@ public actor FoundationModelReplayTextGenerator: FoundationModelTextGenerating {
         let guardrails: FoundationModelGuardrails?
         let adapterURL: URL?
         let generationOptions: FoundationModelGenerationOptions?
+        let imageAttachments: [FoundationModelImageAttachmentDescriptor]
         let source: FoundationModelInvocationSource
         let localeIdentifier: String?
 
-        init(request: FoundationModelTextGenerationRequest) {
+        init(
+            request: FoundationModelTextGenerationRequest,
+            imageAttachmentInspector: FoundationModelImageAttachmentInspector
+        ) throws {
             self.prompt = request.prompt
             self.systemPrompt = request.systemPrompt
             self.modelUseCase = request.modelUseCase
             self.guardrails = request.guardrails
             self.adapterURL = request.adapterURL
             self.generationOptions = request.generationOptions
+            self.imageAttachments = try imageAttachmentInspector.descriptors(
+                for: request.imageAttachments
+            )
             self.source = request.context.source
             self.localeIdentifier = request.context.localeIdentifier
         }
@@ -28,15 +35,31 @@ public actor FoundationModelReplayTextGenerator: FoundationModelTextGenerating {
     public nonisolated let fingerprint: FoundationModelRuntimeFingerprint
 
     private let recordsByKey: [RequestKey: [FoundationModelTextGenerationRecord]]
+    private let imageAttachmentInspector: FoundationModelImageAttachmentInspector
     private var consumedCounts: [RequestKey: Int] = [:]
 
     public init(cassette: FoundationModelTextGenerationCassette) throws {
-        guard cassette.formatVersion == FoundationModelTextGenerationCassette.currentFormatVersion else {
+        try self.init(
+            cassette: cassette,
+            imageAttachmentPolicy: .default
+        )
+    }
+
+    public init(
+        cassette: FoundationModelTextGenerationCassette,
+        imageAttachmentPolicy: FoundationModelImageAttachmentPolicy
+    ) throws {
+        guard FoundationModelTextGenerationCassette.supportedFormatVersions.contains(
+            cassette.formatVersion
+        ) else {
             throw FoundationModelReplayError.unsupportedFormatVersion(cassette.formatVersion)
         }
 
         var seenSequences: Set<Int> = []
         var recordsByKey: [RequestKey: [FoundationModelTextGenerationRecord]] = [:]
+        let imageAttachmentInspector = FoundationModelImageAttachmentInspector(
+            policy: imageAttachmentPolicy
+        )
         for record in cassette.records.sorted(by: { $0.sequence < $1.sequence }) {
             guard record.sequence >= 0 else {
                 throw FoundationModelReplayError.invalidSequence(record.sequence)
@@ -44,17 +67,25 @@ public actor FoundationModelReplayTextGenerator: FoundationModelTextGenerating {
             guard seenSequences.insert(record.sequence).inserted else {
                 throw FoundationModelReplayError.duplicateSequence(record.sequence)
             }
-            recordsByKey[RequestKey(request: record.request), default: []].append(record)
+            let key = try RequestKey(
+                request: record.request,
+                imageAttachmentInspector: imageAttachmentInspector
+            )
+            recordsByKey[key, default: []].append(record)
         }
 
         self.fingerprint = cassette.fingerprint
         self.recordsByKey = recordsByKey
+        self.imageAttachmentInspector = imageAttachmentInspector
     }
 
     public func generateText(
         for request: FoundationModelTextGenerationRequest
     ) async throws -> FoundationModelTextGenerationResult {
-        let key = RequestKey(request: request)
+        let key = try RequestKey(
+            request: request,
+            imageAttachmentInspector: imageAttachmentInspector
+        )
         let fingerprint = try Self.fingerprint(key)
         guard let records = recordsByKey[key] else {
             throw FoundationModelReplayError.noMatchingRecording(

--- a/Sources/FoundationModelEvaluation/FoundationModelTextGenerationCassette.swift
+++ b/Sources/FoundationModelEvaluation/FoundationModelTextGenerationCassette.swift
@@ -2,7 +2,8 @@ import Foundation
 
 /// Codable text-generation recordings paired with the runtime where they were captured.
 public struct FoundationModelTextGenerationCassette: Codable, Equatable, Sendable {
-    public static let currentFormatVersion = 1
+    public static let currentFormatVersion = 2
+    static let supportedFormatVersions = 1...currentFormatVersion
 
     public let formatVersion: Int
     public let fingerprint: FoundationModelRuntimeFingerprint

--- a/Sources/FoundationModelsKit/Models/FoundationModelImageAttachment.swift
+++ b/Sources/FoundationModelsKit/Models/FoundationModelImageAttachment.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+/// A file-backed image included alongside a text-generation prompt.
+///
+/// File URLs are execution inputs. Evaluation recorders replace them with a
+/// metadata-only representation so exported cassettes do not disclose local paths.
+public struct FoundationModelImageAttachment: Codable, Hashable, Sendable {
+    public enum Orientation: String, Codable, CaseIterable, Hashable, Sendable {
+        case up
+        case upMirrored
+        case down
+        case downMirrored
+        case leftMirrored
+        case right
+        case rightMirrored
+        case left
+    }
+
+    private enum StorageKind: String, Codable {
+        case file
+        case metadataOnly
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case label
+        case orientation
+        case storageKind
+        case imageURL
+        case descriptor
+    }
+
+    public let label: String
+    public let orientation: Orientation?
+    /// The local execution source. Evaluation recordings replace this with `nil`.
+    public let imageURL: URL?
+    /// Path-free recording metadata. Executable requests leave this as `nil`.
+    public let descriptor: FoundationModelImageAttachmentDescriptor?
+
+    public init(
+        label: String,
+        imageURL: URL,
+        orientation: Orientation? = nil
+    ) {
+        self.label = label
+        self.orientation = orientation
+        self.imageURL = imageURL
+        self.descriptor = nil
+    }
+
+    /// Creates the path-free representation used by evaluation recordings.
+    public static func metadataOnly(
+        _ descriptor: FoundationModelImageAttachmentDescriptor
+    ) -> Self {
+        Self(
+            label: descriptor.label,
+            orientation: descriptor.orientation,
+            imageURL: nil,
+            descriptor: descriptor
+        )
+    }
+
+    private init(
+        label: String,
+        orientation: Orientation?,
+        imageURL: URL?,
+        descriptor: FoundationModelImageAttachmentDescriptor?
+    ) {
+        self.label = label
+        self.orientation = orientation
+        self.imageURL = imageURL
+        self.descriptor = descriptor
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let storageKind = try container.decode(StorageKind.self, forKey: .storageKind)
+
+        switch storageKind {
+        case .file:
+            self.init(
+                label: try container.decode(String.self, forKey: .label),
+                imageURL: try container.decode(URL.self, forKey: .imageURL),
+                orientation: try container.decodeIfPresent(Orientation.self, forKey: .orientation)
+            )
+        case .metadataOnly:
+            let descriptor = try container.decode(
+                FoundationModelImageAttachmentDescriptor.self,
+                forKey: .descriptor
+            )
+            self = .metadataOnly(descriptor)
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        if let imageURL {
+            try container.encode(StorageKind.file, forKey: .storageKind)
+            try container.encode(label, forKey: .label)
+            try container.encodeIfPresent(orientation, forKey: .orientation)
+            try container.encode(imageURL, forKey: .imageURL)
+        } else if let descriptor {
+            try container.encode(StorageKind.metadataOnly, forKey: .storageKind)
+            try container.encode(descriptor, forKey: .descriptor)
+        } else {
+            throw EncodingError.invalidValue(
+                self,
+                EncodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: "An image attachment requires a file URL or metadata descriptor."
+                )
+            )
+        }
+    }
+}

--- a/Sources/FoundationModelsKit/Models/FoundationModelImageAttachmentDescriptor.swift
+++ b/Sources/FoundationModelsKit/Models/FoundationModelImageAttachmentDescriptor.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Path-free metadata that identifies image content without retaining its pixels.
+public struct FoundationModelImageAttachmentDescriptor: Codable, Hashable, Sendable {
+    public let label: String
+    public let orientation: FoundationModelImageAttachment.Orientation?
+    public let contentTypeIdentifier: String
+    public let byteCount: Int
+    public let sha256Digest: String
+
+    public init(
+        label: String,
+        orientation: FoundationModelImageAttachment.Orientation? = nil,
+        contentTypeIdentifier: String,
+        byteCount: Int,
+        sha256Digest: String
+    ) {
+        self.label = label
+        self.orientation = orientation
+        self.contentTypeIdentifier = contentTypeIdentifier
+        self.byteCount = max(0, byteCount)
+        self.sha256Digest = sha256Digest
+    }
+}

--- a/Sources/FoundationModelsKit/Requests/FoundationModelTextGenerationRequest.swift
+++ b/Sources/FoundationModelsKit/Requests/FoundationModelTextGenerationRequest.swift
@@ -10,7 +10,20 @@ public struct FoundationModelTextGenerationRequest:
     public let guardrails: FoundationModelGuardrails?
     public let adapterURL: URL?
     public let generationOptions: FoundationModelGenerationOptions?
+    /// Labeled file-backed images for iOS 27 and macOS 27 multimodal prompting.
+    public let imageAttachments: [FoundationModelImageAttachment]
     public let context: FoundationModelInvocationContext
+
+    private enum CodingKeys: String, CodingKey {
+        case prompt
+        case systemPrompt
+        case modelUseCase
+        case guardrails
+        case adapterURL
+        case generationOptions
+        case imageAttachments
+        case context
+    }
 
     public init(
         prompt: String,
@@ -21,12 +34,83 @@ public struct FoundationModelTextGenerationRequest:
         generationOptions: FoundationModelGenerationOptions? = nil,
         context: FoundationModelInvocationContext
     ) {
+        self.init(
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            modelUseCase: modelUseCase,
+            guardrails: guardrails,
+            adapterURL: adapterURL,
+            generationOptions: generationOptions,
+            imageAttachments: [],
+            context: context
+        )
+    }
+
+    public init(
+        prompt: String,
+        systemPrompt: String? = nil,
+        modelUseCase: FoundationModelUseCase = .general,
+        guardrails: FoundationModelGuardrails? = nil,
+        adapterURL: URL? = nil,
+        generationOptions: FoundationModelGenerationOptions? = nil,
+        imageAttachments: [FoundationModelImageAttachment],
+        context: FoundationModelInvocationContext
+    ) {
         self.prompt = prompt
         self.systemPrompt = systemPrompt
         self.modelUseCase = modelUseCase
         self.guardrails = guardrails
         self.adapterURL = adapterURL
         self.generationOptions = generationOptions
+        self.imageAttachments = imageAttachments
         self.context = context
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        prompt = try container.decode(String.self, forKey: .prompt)
+        systemPrompt = try container.decodeIfPresent(String.self, forKey: .systemPrompt)
+        modelUseCase = try container.decode(FoundationModelUseCase.self, forKey: .modelUseCase)
+        guardrails = try container.decodeIfPresent(FoundationModelGuardrails.self, forKey: .guardrails)
+        adapterURL = try container.decodeIfPresent(URL.self, forKey: .adapterURL)
+        generationOptions = try container.decodeIfPresent(
+            FoundationModelGenerationOptions.self,
+            forKey: .generationOptions
+        )
+        imageAttachments = try container.decodeIfPresent(
+            [FoundationModelImageAttachment].self,
+            forKey: .imageAttachments
+        ) ?? []
+        context = try container.decode(FoundationModelInvocationContext.self, forKey: .context)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(prompt, forKey: .prompt)
+        try container.encodeIfPresent(systemPrompt, forKey: .systemPrompt)
+        try container.encode(modelUseCase, forKey: .modelUseCase)
+        try container.encodeIfPresent(guardrails, forKey: .guardrails)
+        try container.encodeIfPresent(adapterURL, forKey: .adapterURL)
+        try container.encodeIfPresent(generationOptions, forKey: .generationOptions)
+        if !imageAttachments.isEmpty {
+            try container.encode(imageAttachments, forKey: .imageAttachments)
+        }
+        try container.encode(context, forKey: .context)
+    }
+
+    /// Returns the same semantic request with different image inputs.
+    public func replacingImageAttachments(
+        with imageAttachments: [FoundationModelImageAttachment]
+    ) -> Self {
+        Self(
+            prompt: prompt,
+            systemPrompt: systemPrompt,
+            modelUseCase: modelUseCase,
+            guardrails: guardrails,
+            adapterURL: adapterURL,
+            generationOptions: generationOptions,
+            imageAttachments: imageAttachments,
+            context: context
+        )
     }
 }

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelImageAttachmentInspector.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelImageAttachmentInspector.swift
@@ -1,0 +1,186 @@
+import CryptoKit
+import Foundation
+import ImageIO
+
+/// Validates image inputs and creates path-free descriptors for recording and replay.
+public struct FoundationModelImageAttachmentInspector: Sendable {
+    private struct FileMetadata {
+        let contentTypeIdentifier: String
+        let byteCount: Int
+    }
+
+    public let policy: FoundationModelImageAttachmentPolicy
+
+    public init(policy: FoundationModelImageAttachmentPolicy = .default) {
+        self.policy = policy
+    }
+
+    public func descriptors(
+        for attachments: [FoundationModelImageAttachment]
+    ) throws -> [FoundationModelImageAttachmentDescriptor] {
+        try validateCollection(attachments)
+        return try attachments.map(descriptor)
+    }
+
+    /// Validates executable files without calculating recording fingerprints.
+    public func validateForExecution(
+        _ attachments: [FoundationModelImageAttachment]
+    ) throws {
+        try validateCollection(attachments)
+        for attachment in attachments {
+            guard attachment.imageURL != nil, attachment.descriptor == nil else {
+                throw FoundationModelsKitError.invalidRequest(
+                    "Metadata-only image attachment '\(attachment.label)' cannot be executed"
+                )
+            }
+            _ = try fileMetadata(for: attachment)
+        }
+    }
+
+    private func validateCollection(
+        _ attachments: [FoundationModelImageAttachment]
+    ) throws {
+        guard attachments.count <= policy.maximumAttachmentCount else {
+            throw FoundationModelsKitError.invalidRequest(
+                "Image attachment count exceeds the configured maximum of \(policy.maximumAttachmentCount)"
+            )
+        }
+
+        try validateLabels(attachments.map(\.label))
+    }
+
+    private func descriptor(
+        for attachment: FoundationModelImageAttachment
+    ) throws -> FoundationModelImageAttachmentDescriptor {
+        if let descriptor = attachment.descriptor {
+            try validate(descriptor, for: attachment)
+            return descriptor
+        }
+
+        guard let imageURL = attachment.imageURL else {
+            throw FoundationModelsKitError.invalidRequest(
+                "Image attachment '\(attachment.label)' has no executable file URL"
+            )
+        }
+        let metadata = try fileMetadata(for: attachment)
+
+        return FoundationModelImageAttachmentDescriptor(
+            label: attachment.label,
+            orientation: attachment.orientation,
+            contentTypeIdentifier: metadata.contentTypeIdentifier,
+            byteCount: metadata.byteCount,
+            sha256Digest: try sha256Digest(of: imageURL, label: attachment.label)
+        )
+    }
+
+    private func fileMetadata(
+        for attachment: FoundationModelImageAttachment
+    ) throws -> FileMetadata {
+        guard let imageURL = attachment.imageURL, imageURL.isFileURL else {
+            throw FoundationModelsKitError.invalidRequest(
+                "Image attachment '\(attachment.label)' must use a local file URL"
+            )
+        }
+
+        let values: URLResourceValues
+        do {
+            values = try imageURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+        } catch {
+            throw FoundationModelsKitError.invalidRequest(
+                "Image attachment '\(attachment.label)' cannot be inspected"
+            )
+        }
+
+        guard values.isRegularFile == true, let byteCount = values.fileSize, byteCount > 0 else {
+            throw FoundationModelsKitError.invalidRequest(
+                "Image attachment '\(attachment.label)' must reference a nonempty regular file"
+            )
+        }
+        guard byteCount <= policy.maximumBytesPerAttachment else {
+            throw FoundationModelsKitError.invalidRequest(
+                "Image attachment '\(attachment.label)' exceeds the configured byte limit"
+            )
+        }
+        guard let imageSource = CGImageSourceCreateWithURL(imageURL as CFURL, nil),
+              CGImageSourceGetCount(imageSource) > 0,
+              let contentType = CGImageSourceGetType(imageSource) as String? else {
+            throw FoundationModelsKitError.invalidRequest(
+                "Image attachment '\(attachment.label)' is not a supported image file"
+            )
+        }
+
+        return FileMetadata(
+            contentTypeIdentifier: contentType,
+            byteCount: byteCount
+        )
+    }
+
+    private func validate(
+        _ descriptor: FoundationModelImageAttachmentDescriptor,
+        for attachment: FoundationModelImageAttachment
+    ) throws {
+        let digestCharacters = CharacterSet(charactersIn: "0123456789abcdef")
+        guard descriptor.label == attachment.label,
+              descriptor.orientation == attachment.orientation,
+              !descriptor.contentTypeIdentifier.isEmpty,
+              descriptor.byteCount > 0,
+              descriptor.byteCount <= policy.maximumBytesPerAttachment,
+              descriptor.sha256Digest.count == 64,
+              descriptor.sha256Digest.unicodeScalars.allSatisfy(digestCharacters.contains) else {
+            throw FoundationModelsKitError.invalidRequest(
+                "Image attachment '\(attachment.label)' has invalid recorded metadata"
+            )
+        }
+    }
+
+    private func validateLabels(_ labels: [String]) throws {
+        var uniqueLabels: Set<String> = []
+        for label in labels {
+            let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, trimmed == label,
+                  !label.unicodeScalars.contains(
+                    where: CharacterSet.controlCharacters.contains
+                  ) else {
+                throw FoundationModelsKitError.invalidRequest(
+                    "Image attachment labels must be nonempty and contain no surrounding " +
+                    "whitespace or control characters"
+                )
+            }
+            guard uniqueLabels.insert(label).inserted else {
+                throw FoundationModelsKitError.invalidRequest(
+                    "Image attachment labels must be unique"
+                )
+            }
+        }
+    }
+
+    private func sha256Digest(of url: URL, label: String) throws -> String {
+        let fileHandle: FileHandle
+        do {
+            fileHandle = try FileHandle(forReadingFrom: url)
+        } catch {
+            throw FoundationModelsKitError.invalidRequest(
+                "Image attachment '\(label)' cannot be read"
+            )
+        }
+        defer { try? fileHandle.close() }
+
+        var hasher = SHA256()
+        do {
+            while let chunk = try fileHandle.read(upToCount: 64 * 1_024), !chunk.isEmpty {
+                hasher.update(data: chunk)
+            }
+        } catch {
+            throw FoundationModelsKitError.invalidRequest(
+                "Image attachment '\(label)' could not be fingerprinted"
+            )
+        }
+
+        return hasher.finalize().map(Self.hexByte).joined()
+    }
+
+    private static func hexByte(_ byte: UInt8) -> String {
+        let value = String(byte, radix: 16)
+        return value.count == 1 ? "0\(value)" : value
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelImageAttachmentPolicy.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelImageAttachmentPolicy.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Local safety budgets applied before image content reaches a model session.
+///
+/// These are package defaults rather than documented model limits. Apps can tune
+/// them for their own memory budget and accepted workflows.
+public struct FoundationModelImageAttachmentPolicy: Hashable, Sendable {
+    public static let `default` = Self()
+
+    public let maximumAttachmentCount: Int
+    public let maximumBytesPerAttachment: Int
+
+    public init(
+        maximumAttachmentCount: Int = 8,
+        maximumBytesPerAttachment: Int = 20 * 1_024 * 1_024
+    ) {
+        self.maximumAttachmentCount = max(1, maximumAttachmentCount)
+        self.maximumBytesPerAttachment = max(1, maximumBytesPerAttachment)
+    }
+}

--- a/Sources/FoundationModelsKit/Runtime/FoundationModelsTextGenerator.swift
+++ b/Sources/FoundationModelsKit/Runtime/FoundationModelsTextGenerator.swift
@@ -2,14 +2,28 @@ import Foundation
 import FoundationModels
 
 public struct FoundationModelsTextGenerator: FoundationModelTextGenerating {
-    public init() {}
+    public let imageAttachmentPolicy: FoundationModelImageAttachmentPolicy
 
-    public func generateText(for request: FoundationModelTextGenerationRequest) async throws -> FoundationModelTextGenerationResult {
+    public init() {
+        self.init(imageAttachmentPolicy: .default)
+    }
+
+    public init(imageAttachmentPolicy: FoundationModelImageAttachmentPolicy) {
+        self.imageAttachmentPolicy = imageAttachmentPolicy
+    }
+
+    public func generateText(
+        for request: FoundationModelTextGenerationRequest
+    ) async throws -> FoundationModelTextGenerationResult {
         let prompt = request.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !prompt.isEmpty else {
             throw FoundationModelsKitError.invalidRequest("Missing prompt")
         }
 
+        let responsePrompt = try makePrompt(
+            text: prompt,
+            attachments: request.imageAttachments
+        )
         let model = try FoundationModelsModelFactory.makeModel(
             useCase: request.modelUseCase,
             guardrails: request.guardrails ?? .default,
@@ -30,11 +44,11 @@ public struct FoundationModelsTextGenerator: FoundationModelTextGenerating {
         let responseContent: String
         if let generationOptions = request.generationOptions {
             responseContent = try await session.respond(
-                to: Prompt(prompt),
+                to: responsePrompt,
                 options: generationOptions.foundationModelsValue
             ).content
         } else {
-            responseContent = try await session.respond(to: Prompt(prompt)).content
+            responseContent = try await session.respond(to: responsePrompt).content
         }
 
         let tokenCount = await session.transcript.tokenCount(using: model)
@@ -48,4 +62,61 @@ public struct FoundationModelsTextGenerator: FoundationModelTextGenerating {
             )
         )
     }
+
+    private func makePrompt(
+        text: String,
+        attachments: [FoundationModelImageAttachment]
+    ) throws -> Prompt {
+        guard !attachments.isEmpty else {
+            return Prompt(text)
+        }
+
+        #if compiler(>=6.4)
+        guard #available(iOS 27.0, macOS 27.0, *) else {
+            throw FoundationModelsKitError.unavailableCapability(
+                "Image prompting requires iOS 27 or macOS 27"
+            )
+        }
+        try FoundationModelImageAttachmentInspector(
+            policy: imageAttachmentPolicy
+        ).validateForExecution(attachments)
+
+        return Prompt {
+            text
+            for attachment in attachments {
+                if let imageURL = attachment.imageURL {
+                    Attachment(
+                        imageURL: imageURL,
+                        orientation: attachment.orientation?.foundationModelsValue
+                    )
+                    .label(attachment.label)
+                }
+            }
+        }
+        #else
+        throw FoundationModelsKitError.unavailableCapability(
+            "Image prompting requires the Xcode 27 SDK"
+        )
+        #endif
+    }
 }
+
+#if compiler(>=6.4)
+import ImageIO
+
+extension FoundationModelImageAttachment.Orientation {
+    @available(iOS 27.0, macOS 27.0, *)
+    fileprivate var foundationModelsValue: CGImagePropertyOrientation {
+        switch self {
+        case .up: .up
+        case .upMirrored: .upMirrored
+        case .down: .down
+        case .downMirrored: .downMirrored
+        case .leftMirrored: .leftMirrored
+        case .right: .right
+        case .rightMirrored: .rightMirrored
+        case .left: .left
+        }
+    }
+}
+#endif

--- a/Tests/FoundationModelEvaluationTests/FoundationModelRecordReplayTests.swift
+++ b/Tests/FoundationModelEvaluationTests/FoundationModelRecordReplayTests.swift
@@ -124,6 +124,137 @@ struct FoundationModelRecordReplayTests {
         #expect(decoded == cassette)
     }
 
+    @Test("Replay remains compatible with format 1 text-only cassettes")
+    func replaysFormatOneCassette() async throws {
+        let result = FoundationModelTextGenerationResult(content: "legacy")
+        let cassette = FoundationModelTextGenerationCassette(
+            formatVersion: 1,
+            fingerprint: testFingerprint,
+            records: [
+                FoundationModelTextGenerationRecord(
+                    sequence: 0,
+                    request: request(correlationID: UUID()),
+                    outcome: .success(result)
+                )
+            ]
+        )
+
+        let replay = try FoundationModelReplayTextGenerator(cassette: cassette)
+
+        #expect(try await replay.generateText(
+            for: request(correlationID: UUID())
+        ) == result)
+    }
+
+    @Test("Recorder replaces image paths with metadata and replay matches image content")
+    func redactsAndReplaysImageAttachments() async throws {
+        let recordedURL = try temporaryEvaluationPNG(named: "private-original.png")
+        let replayURL = try temporaryEvaluationPNG(named: "renamed-copy.png")
+        defer {
+            removeTemporaryEvaluationItem(containing: recordedURL)
+            removeTemporaryEvaluationItem(containing: replayURL)
+        }
+        let result = FoundationModelTextGenerationResult(content: "image result")
+        let recorder = FoundationModelRecordingTextGenerator(
+            base: ScriptedTextGenerator(outcomes: [.success(result)])
+        )
+        let recordedRequest = request(
+            correlationID: UUID(),
+            imageAttachments: [
+                FoundationModelImageAttachment(
+                    label: "subject",
+                    imageURL: recordedURL
+                )
+            ]
+        )
+
+        _ = try await recorder.generateText(for: recordedRequest)
+        let cassette = await recorder.cassette(fingerprint: testFingerprint)
+        let encoded = try JSONEncoder().encode(cassette)
+        let json = try #require(String(data: encoded, encoding: .utf8))
+        let recordedAttachment = try #require(
+            cassette.records.first?.request.imageAttachments.first
+        )
+
+        #expect(recordedAttachment.imageURL == nil)
+        #expect(recordedAttachment.descriptor?.sha256Digest.count == 64)
+        #expect(!json.contains(recordedURL.path()))
+        #expect(!json.contains("private-original.png"))
+
+        let replay = try FoundationModelReplayTextGenerator(cassette: cassette)
+        let replayRequest = request(
+            correlationID: UUID(),
+            imageAttachments: [
+                FoundationModelImageAttachment(
+                    label: "subject",
+                    imageURL: replayURL
+                )
+            ]
+        )
+
+        #expect(try await replay.generateText(for: replayRequest) == result)
+    }
+
+    @Test("Replay rejects different image content and malformed recorded metadata")
+    func rejectsMismatchedImageContent() async throws {
+        let imageURL = try temporaryEvaluationPNG(named: "original.png")
+        let differentURL = try temporaryEvaluationFile(
+            named: "different.png",
+            data: try #require(Data(base64Encoded: differentEvaluationPNGBase64))
+        )
+        defer {
+            removeTemporaryEvaluationItem(containing: imageURL)
+            removeTemporaryEvaluationItem(containing: differentURL)
+        }
+        let result = FoundationModelTextGenerationResult(content: "image result")
+        let recorder = FoundationModelRecordingTextGenerator(
+            base: ScriptedTextGenerator(outcomes: [.success(result)])
+        )
+        _ = try await recorder.generateText(for: request(
+            correlationID: UUID(),
+            imageAttachments: [
+                FoundationModelImageAttachment(label: "subject", imageURL: imageURL)
+            ]
+        ))
+        let cassette = await recorder.cassette(fingerprint: testFingerprint)
+        let replay = try FoundationModelReplayTextGenerator(cassette: cassette)
+
+        await #expect(throws: FoundationModelReplayError.self) {
+            _ = try await replay.generateText(for: request(
+                correlationID: UUID(),
+                imageAttachments: [
+                    FoundationModelImageAttachment(label: "subject", imageURL: differentURL)
+                ]
+            ))
+        }
+
+        let malformed = FoundationModelImageAttachment.metadataOnly(
+            FoundationModelImageAttachmentDescriptor(
+                label: "subject",
+                contentTypeIdentifier: "public.png",
+                byteCount: 1,
+                sha256Digest: "not-a-digest"
+            )
+        )
+        let malformedCassette = FoundationModelTextGenerationCassette(
+            fingerprint: testFingerprint,
+            records: [
+                FoundationModelTextGenerationRecord(
+                    sequence: 0,
+                    request: request(
+                        correlationID: UUID(),
+                        imageAttachments: [malformed]
+                    ),
+                    outcome: .success(result)
+                )
+            ]
+        )
+
+        #expect(throws: FoundationModelsKitError.self) {
+            _ = try FoundationModelReplayTextGenerator(cassette: malformedCassette)
+        }
+    }
+
     @Test("Golden comparisons exclude timing and report stable field drift")
     func comparesStableEvaluationFields() {
         let firstTrace = trace(
@@ -160,11 +291,15 @@ struct FoundationModelRecordReplayTests {
         )
     }
 
-    private func request(correlationID: UUID) -> FoundationModelTextGenerationRequest {
+    private func request(
+        correlationID: UUID,
+        imageAttachments: [FoundationModelImageAttachment] = []
+    ) -> FoundationModelTextGenerationRequest {
         FoundationModelTextGenerationRequest(
             prompt: "Prompt",
             systemPrompt: "Instructions",
             generationOptions: FoundationModelGenerationOptions(temperature: 0.2),
+            imageAttachments: imageAttachments,
             context: FoundationModelInvocationContext(
                 source: .automation,
                 localeIdentifier: "en_US",
@@ -204,6 +339,37 @@ struct FoundationModelRecordReplayTests {
             localeIdentifier: "en_US"
         )
     }
+}
+
+private let evaluationPNGBase64 = """
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=
+"""
+
+private let differentEvaluationPNGBase64 = """
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Y9Z8i8AAAAASUVORK5CYII=
+"""
+
+private func temporaryEvaluationPNG(named name: String) throws -> URL {
+    try temporaryEvaluationFile(
+        named: name,
+        data: try #require(Data(base64Encoded: evaluationPNGBase64))
+    )
+}
+
+private func temporaryEvaluationFile(named name: String, data: Data) throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appending(path: "FoundationModelEvaluationTests-\(UUID())", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(
+        at: directory,
+        withIntermediateDirectories: true
+    )
+    let url = directory.appending(path: name)
+    try data.write(to: url, options: .atomic)
+    return url
+}
+
+private func removeTemporaryEvaluationItem(containing url: URL) {
+    try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
 }
 
 private actor ScriptedTextGenerator: FoundationModelTextGenerating {

--- a/Tests/FoundationModelsKitTests/FoundationModelImageAttachmentTests.swift
+++ b/Tests/FoundationModelsKitTests/FoundationModelImageAttachmentTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import FoundationModelsKit
+import Testing
+
+@Suite("Foundation Model image attachments")
+struct FoundationModelImageAttachmentTests {
+    @Test("Inspector validates an image and creates a stable path-free descriptor")
+    func inspectsImage() throws {
+        let expectedPNGData = try pngData()
+        let firstURL = try temporaryPNG(named: "first.png")
+        let secondURL = try temporaryPNG(named: "second.png")
+        defer {
+            removeTemporaryItem(containing: firstURL)
+            removeTemporaryItem(containing: secondURL)
+        }
+        let inspector = FoundationModelImageAttachmentInspector()
+
+        let first = try inspector.descriptors(for: [
+            FoundationModelImageAttachment(
+                label: "source-image",
+                imageURL: firstURL,
+                orientation: .right
+            )
+        ]).first
+        let second = try inspector.descriptors(for: [
+            FoundationModelImageAttachment(
+                label: "source-image",
+                imageURL: secondURL,
+                orientation: .right
+            )
+        ]).first
+
+        #expect(first?.label == "source-image")
+        #expect(first?.orientation == .right)
+        #expect(first?.contentTypeIdentifier.localizedStandardContains("png") == true)
+        #expect(first?.byteCount == expectedPNGData.count)
+        #expect(first?.sha256Digest.count == 64)
+        #expect(first == second)
+    }
+
+    @Test("Inspector rejects duplicate labels, non-images, and oversized inputs")
+    func rejectsUnsafeInputs() throws {
+        let expectedPNGData = try pngData()
+        let imageURL = try temporaryPNG(named: "valid.png")
+        let textURL = try temporaryFile(named: "not-image.txt", data: Data("hello".utf8))
+        defer {
+            removeTemporaryItem(containing: imageURL)
+            removeTemporaryItem(containing: textURL)
+        }
+        let duplicate = FoundationModelImageAttachment(label: "same", imageURL: imageURL)
+
+        #expect(throws: FoundationModelsKitError.self) {
+            _ = try FoundationModelImageAttachmentInspector().descriptors(
+                for: [duplicate, duplicate]
+            )
+        }
+        #expect(throws: FoundationModelsKitError.self) {
+            _ = try FoundationModelImageAttachmentInspector().descriptors(for: [
+                FoundationModelImageAttachment(label: "text", imageURL: textURL)
+            ])
+        }
+        #expect(throws: FoundationModelsKitError.self) {
+            _ = try FoundationModelImageAttachmentInspector(
+                policy: FoundationModelImageAttachmentPolicy(
+                    maximumBytesPerAttachment: expectedPNGData.count - 1
+                )
+            ).descriptors(for: [
+                FoundationModelImageAttachment(label: "large", imageURL: imageURL)
+            ])
+        }
+    }
+
+    @Test("Metadata-only attachments encode without a file URL")
+    func metadataOnlyEncodingOmitsPath() throws {
+        let descriptor = FoundationModelImageAttachmentDescriptor(
+            label: "private-photo",
+            contentTypeIdentifier: "public.png",
+            byteCount: 42,
+            sha256Digest: String(repeating: "a", count: 64)
+        )
+        let attachment = FoundationModelImageAttachment.metadataOnly(descriptor)
+
+        let data = try JSONEncoder().encode(attachment)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try JSONDecoder().decode(
+            FoundationModelImageAttachment.self,
+            from: data
+        )
+
+        #expect(!json.contains("imageURL"))
+        #expect(decoded == attachment)
+        #expect(decoded.imageURL == nil)
+        #expect(decoded.descriptor == descriptor)
+    }
+
+    @Test("Requests without imageAttachments retain their legacy Codable shape")
+    func requestCodableDefaultsToNoAttachments() throws {
+        let request = FoundationModelTextGenerationRequest(
+            prompt: "Prompt",
+            context: FoundationModelInvocationContext(source: .app)
+        )
+
+        let data = try JSONEncoder().encode(request)
+        let json = try #require(String(data: data, encoding: .utf8))
+        let decoded = try JSONDecoder().decode(
+            FoundationModelTextGenerationRequest.self,
+            from: data
+        )
+
+        #expect(!json.contains("imageAttachments"))
+        #expect(decoded == request)
+        #expect(decoded.imageAttachments.isEmpty)
+    }
+}
+
+private let pngBase64 = """
+iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=
+"""
+
+private func pngData() throws -> Data {
+    try #require(Data(base64Encoded: pngBase64))
+}
+
+private func temporaryPNG(named name: String) throws -> URL {
+    try temporaryFile(named: name, data: pngData())
+}
+
+private func temporaryFile(named name: String, data: Data) throws -> URL {
+    let directory = FileManager.default.temporaryDirectory
+        .appending(path: "FoundationModelsKitTests-\(UUID())", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(
+        at: directory,
+        withIntermediateDirectories: true
+    )
+    let url = directory.appending(path: name)
+    try data.write(to: url, options: .atomic)
+    return url
+}
+
+private func removeTemporaryItem(containing url: URL) {
+    try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+}


### PR DESCRIPTION
## Summary

- add typed file-backed image attachments to text-generation requests for iOS 27 and macOS 27
- validate attachment labels, file type, count, and byte budgets before model execution
- redact image paths and pixels from evaluation cassettes while preserving deterministic replay through SHA-256 content descriptors
- preserve OS 26 text-only behavior and existing public initializer signatures

## Privacy model

Executable requests retain local file URLs because the Foundation Models session needs them. `FoundationModelRecordingTextGenerator` replaces each image with path-free metadata before retaining a record:

- label and orientation
- Image I/O type identifier
- byte count
- SHA-256 digest

Replay matches image content rather than paths. Digests are pseudonymous metadata, not anonymization. Cassette format 2 prevents older clients from silently treating image-backed fixtures as text-only, while the new replay implementation continues to accept format 1 text-only cassettes.

## Compatibility

- OS 26 text-only request behavior is unchanged
- the Xcode 27/iOS 27/macOS 27 native `Attachment` bridge is compiler- and availability-gated
- API digester reports no breaking changes across all products

## Validation

- Xcode 26.6: 208 tests in 34 suites passed (excluding two environment-dependent Keychain tests under the noninteractive runner)
- production Swift package build passed
- strict SwiftLint on every changed Swift file: 0 violations
- `swift package diagnose-api-breaking-changes origin/main`: no breaking changes
- `git diff --check` passed

## SDK verification

Apple's iOS 27 `Attachment` API is still beta and Xcode 27 is not installed on this machine. The native bridge follows [Apple's published multimodal prompting API](https://developer.apple.com/documentation/foundationmodels/analyzing-images-with-multimodal-prompting). Final Xcode 27 compilation and on-device runtime validation remain follow-up verification items while the SDK is in beta.